### PR TITLE
Add workflow for maintaining major release tags

### DIFF
--- a/.github/workflows/release-tags.yml
+++ b/.github/workflows/release-tags.yml
@@ -1,0 +1,41 @@
+name: Release Tags
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+
+jobs:
+  move-major-tag:
+    name: Move major release tag
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure git identity
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Move major tag to the release commit
+        env:
+          RELEASE_TAG: ${{ github.ref_name }}
+        run: |
+          case "$RELEASE_TAG" in
+            v[0-9]*.[0-9]*.[0-9]*)
+              major_tag="${RELEASE_TAG%%.*}"
+              ;;
+            *)
+              echo "Unexpected tag format: $RELEASE_TAG" >&2
+              exit 1
+              ;;
+          esac
+
+          git tag -f "$major_tag" "$GITHUB_SHA"
+          git push origin "refs/tags/$major_tag" --force

--- a/README.md
+++ b/README.md
@@ -46,6 +46,23 @@ jobs:
       debug_artifacts: true
 ```
 
+Versioning guidance:
+
+- use `@v1` in downstream repositories for the stable major line
+- publish fixed release tags such as `v1.0.0` for exact version pinning
+- this repository includes [`.github/workflows/release-tags.yml`](/Users/shaypalachy/clones/pr-agent-context/.github/workflows/release-tags.yml), which automatically moves `v1` when a `v1.x.y` tag is pushed
+
+Example release flow in this repository:
+
+```bash
+git checkout main
+git pull --ff-only origin main
+git tag v1.0.1
+git push origin v1.0.1
+```
+
+After the version tag push completes, the workflow force-updates the matching major tag to the same commit.
+
 The reusable workflow inputs are:
 
 - `tool_ref`: ref of `shaypal5/pr-agent-context` to run, default `"v1"`


### PR DESCRIPTION
## Summary
- add a small GitHub Actions workflow that moves the matching major tag when a semantic version tag is pushed
- document the expected downstream pinning pattern and release flow in the README

## Details
This adds `.github/workflows/release-tags.yml`, which runs on pushes of tags matching `v*.*.*`.

When a tag like `v1.0.1` is pushed, the workflow:
- checks out the repository with full history
- configures a bot git identity
- derives the matching major tag (`v1`)
- force-updates that major tag to the release commit

This keeps downstream reusable-workflow references such as:

```yaml
uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v1
```

aligned with the latest `v1.x.y` release without needing a manual `git tag -f v1` step.

## Verification
- `pytest`
