### PR TITLE
Use pr-agent-context in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,21 @@ jobs:
           files: ./coverage.xml
           flags: py${{ matrix.python-version }}
           name: py${{ matrix.python-version }}
+
+  pr-agent-context:
+    name: PR agent context
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    needs: [test]
+    permissions:
+      contents: read
+      actions: read
+      pull-requests: write
+    uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v1
+    with:
+      tool_ref: v1
+      target_patch_coverage: "100"
+      include_review_comments: true
+      include_failing_jobs: true
+      include_patch_coverage: true
+      coverage_artifact_prefix: pr-agent-context-coverage
+      debug_artifacts: true


### PR DESCRIPTION
## Summary
- add a PR-only `pr-agent-context` job to this repository's own CI
- run it after the existing test matrix so it can reuse the raw coverage artifacts already uploaded by the matrix jobs
- pin the reusable workflow through the moving `v1` major tag, while keeping the in-workflow `tool_ref` at `v1`

## Details
This adds a final reusable workflow job to `.github/workflows/ci.yml` with:
- `contents: read`
- `actions: read`
- `pull-requests: write`

It uses the same artifact prefix already produced by the test matrix:
- `pr-agent-context-coverage`

So on PRs, this repo now dogfoods its own managed PR context comment generation, review-thread collection, failing-job collection, and patch-coverage analysis.
