### PR TITLE
Skip coverage files that fail during combine

### DIFF
--- a/src/pr_agent_context/coverage/combine.py
+++ b/src/pr_agent_context/coverage/combine.py
@@ -21,9 +21,12 @@ def build_combined_coverage(*, workspace: Path, coverage_files: list[Path]) -> C
         config_file=str(config_file) if config_file else False,
         data_file=str(combined_output_dir / ".coverage"),
     )
-    valid_coverage_files = _filter_valid_coverage_files(coverage_files)
-    if valid_coverage_files:
-        coverage.combine(data_paths=[str(path) for path in valid_coverage_files], strict=False)
+    normalized_coverage_files = _normalize_coverage_files(
+        coverage_files=coverage_files,
+        config_file=config_file,
+    )
+    if normalized_coverage_files:
+        coverage.combine(data_paths=[str(path) for path in normalized_coverage_files], strict=False)
         coverage.save()
         coverage.load()
     return coverage
@@ -43,6 +46,28 @@ def _filter_valid_coverage_files(coverage_files: list[Path]) -> list[Path]:
         if _is_valid_coverage_file(path):
             valid_files.append(path)
     return valid_files
+
+
+def _normalize_coverage_files(
+    *,
+    coverage_files: list[Path],
+    config_file: Path | None,
+) -> list[Path]:
+    normalized_output_dir = Path(tempfile.mkdtemp(prefix="pr-agent-context-coverage-inputs-"))
+    normalized_files: list[Path] = []
+    for index, path in enumerate(_filter_valid_coverage_files(coverage_files), start=1):
+        normalized_path = normalized_output_dir / f".coverage.normalized.{index}"
+        coverage = Coverage(
+            config_file=str(config_file) if config_file else False,
+            data_file=str(normalized_path),
+        )
+        try:
+            coverage.combine(data_paths=[str(path)], strict=False)
+            coverage.save()
+            normalized_files.append(normalized_path)
+        except DataError:
+            continue
+    return normalized_files
 
 
 def _is_valid_coverage_file(path: Path) -> bool:

--- a/tests/test_patch_coverage.py
+++ b/tests/test_patch_coverage.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from pathlib import Path
 
 from coverage import Coverage
+from coverage.exceptions import DataError
 
+from pr_agent_context.coverage import combine as combine_module
 from pr_agent_context.coverage.combine import build_combined_coverage
 from pr_agent_context.coverage.patch import compute_patch_coverage
 
@@ -80,6 +82,43 @@ def test_build_combined_coverage_skips_malformed_data_files(tmp_path):
 
     assert statements == [1, 2, 3, 4]
     assert missing == [4]
+
+
+def test_build_combined_coverage_skips_files_that_fail_during_combine(tmp_path, monkeypatch):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    module_path = repo / "src" / "pkg" / "module.py"
+    _write_file(
+        module_path,
+        "def alpha(flag):\n"
+        "    if flag:\n"
+        "        return 1\n"
+        "    return 2\n\n"
+        "def beta(flag):\n"
+        "    if flag:\n"
+        "        return 3\n"
+        "    return 4\n",
+    )
+
+    first = tmp_path / ".coverage.first"
+    second = tmp_path / ".coverage.second"
+    _build_coverage_data(first, [(module_path, "alpha(True)")])
+    _build_coverage_data(second, [(module_path, "beta(True)")])
+
+    real_combine = combine_module.Coverage.combine
+
+    def flaky_combine(self, data_paths=None, strict=False, keep=False):
+        if data_paths == [str(second)]:
+            raise DataError("database disk image is malformed")
+        return real_combine(self, data_paths=data_paths, strict=strict, keep=keep)
+
+    monkeypatch.setattr(combine_module.Coverage, "combine", flaky_combine)
+
+    combined = build_combined_coverage(workspace=repo, coverage_files=[first, second])
+    _filename, statements, _excluded, missing, _formatted = combined.analysis2(str(module_path))
+
+    assert statements == [1, 2, 3, 4, 6, 7, 8, 9]
+    assert missing == [4, 7, 8, 9]
 
 
 def test_compute_patch_coverage_reports_explicit_uncovered_lines(tmp_path):


### PR DESCRIPTION
## Summary
- harden coverage combining by normalizing each raw `.coverage*` input one-by-one before the final merge
- skip inputs that still raise `coverage.exceptions.DataError` during the real combine path
- add a regression for files that pass shallow validation but still fail during `coverage.combine()`

## Why
PR Agent Context currently validates raw coverage artifacts with `CoverageData.read()`, but some corrupted SQLite coverage files can still fail later during the actual merge/update path inside `coverage.combine()`. When that happens, the workflow crashes instead of degrading gracefully.

## Testing
- `pytest -q tests/test_patch_coverage.py`
- `pytest -q`
- `ruff check src tests`
- `ruff format --check .`