### PR TITLE
Add external header and metadata footer to managed comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,16 @@ The managed comment body shape is:
 
 ````markdown
 <!-- pr-agent-context:managed-comment; schema=v3; pr=<PR>; run_id=<RUN_ID>; run_attempt=<ATTEMPT>; head_sha=<HEAD_SHA>; tool_ref=<TOOL_REF> -->
+pr-agent-context report:
 ```markdown
 <rendered prompt>
+```
+Run metadata:
+```
+Tool ref: <TOOL_REF>
+Tool version: <TOOL_VERSION>
+Workflow run: <RUN_ID> attempt <ATTEMPT>
+PR head commit: <HEAD_SHA>
 ```
 ````
 

--- a/src/pr_agent_context/cli.py
+++ b/src/pr_agent_context/cli.py
@@ -181,9 +181,6 @@ def _build_failure_markdown(*, context: dict[str, object], error: Exception) -> 
         "🚨 `pr-agent-context` failed while preparing PR context.",
         "",
         f"PR: #{context['pull_request_number']}",
-        f"Head commit: {context['head_sha']}",
-        f"Tool ref: {context.get('tool_ref') or 'unknown'}",
-        f"Version: {__version__}",
         f"Error: {type(error).__name__}: {error}",
     ]
     if run_url:

--- a/src/pr_agent_context/constants.py
+++ b/src/pr_agent_context/constants.py
@@ -4,11 +4,6 @@ MANAGED_COMMENT_MARKER_PREFIX = "<!-- pr-agent-context:managed-comment"
 MANAGED_COMMENT_SCHEMA_VERSION = "v3"
 
 DEFAULT_PROMPT_OPENING = (
-    "Run metadata:\n"
-    "- Tool ref: {tool_ref}\n"
-    "- Tool version: {tool_version}\n"
-    "- Workflow run: {run_id} attempt {run_attempt}\n"
-    "- PR head commit: {head_sha}\n\n"
     "Below are the details of possibly unresolved review comments and/or "
     "(possibly) failing checks on PR #{pr_number}.\n\n"
     "For each unresolved comment (if any), recommend one of: resolve as "
@@ -22,11 +17,6 @@ DEFAULT_PROMPT_OPENING = (
 )
 
 DEFAULT_ALL_CLEAR_PROMPT = (
-    "Run metadata:\n"
-    "- Tool ref: {tool_ref}\n"
-    "- Tool version: {tool_version}\n"
-    "- Workflow run: {run_id} attempt {run_attempt}\n"
-    "- PR head commit: {head_sha}\n\n"
     "No unresolved review comments, failing checks, or actionable patch "
     "coverage gaps were found on PR #{pr_number}. Treat this PR as all clear "
     "unless new signals appear."

--- a/src/pr_agent_context/prompt/render.py
+++ b/src/pr_agent_context/prompt/render.py
@@ -99,10 +99,6 @@ def render_prompt(
             "opening_instructions": _build_opening_instructions(
                 pull_request_number=pull_request_number,
                 head_sha=head_sha,
-                run_id=run_id,
-                run_attempt=run_attempt,
-                tool_ref=tool_ref,
-                tool_version=tool_version,
                 has_actionable_items=has_actionable_items,
                 include_review_comments=include_review_comments,
                 include_failing_checks=include_failing_checks,
@@ -156,17 +152,26 @@ def build_managed_comment_body(
             tool_ref=tool_ref,
         )
     )
-    return f"{marker}\n{_wrap_markdown_code_block(markdown)}"
+    metadata = _render_run_metadata(
+        tool_ref=tool_ref,
+        tool_version=__version__,
+        run_id=run_id,
+        run_attempt=run_attempt,
+        head_sha=head_sha,
+    )
+    return (
+        f"{marker}\n"
+        "pr-agent-context report:\n"
+        f"{_wrap_code_block(markdown, info_string='markdown')}\n"
+        "Run metadata:\n"
+        f"{_wrap_code_block(metadata)}"
+    )
 
 
 def _build_opening_instructions(
     *,
     pull_request_number: int,
     head_sha: str | None,
-    run_id: int,
-    run_attempt: int,
-    tool_ref: str,
-    tool_version: str,
     has_actionable_items: bool,
     include_review_comments: bool,
     include_failing_checks: bool,
@@ -175,11 +180,6 @@ def _build_opening_instructions(
     if has_actionable_items:
         return DEFAULT_PROMPT_OPENING.format(
             pr_number=pull_request_number,
-            head_sha=head_sha or "unknown",
-            run_id=run_id,
-            run_attempt=run_attempt,
-            tool_ref=tool_ref,
-            tool_version=tool_version,
         )
 
     disabled_checks = [
@@ -194,11 +194,6 @@ def _build_opening_instructions(
     if not disabled_checks:
         return DEFAULT_ALL_CLEAR_PROMPT.format(
             pr_number=pull_request_number,
-            head_sha=head_sha or "unknown",
-            run_id=run_id,
-            run_attempt=run_attempt,
-            tool_ref=tool_ref,
-            tool_version=tool_version,
         )
     return (
         "No actionable items were found in the enabled checks for PR "
@@ -558,7 +553,29 @@ def _sanitize_block(text: str) -> str:
     return normalized.replace("```", "~~~")
 
 
+def _render_run_metadata(
+    *,
+    tool_ref: str,
+    tool_version: str,
+    run_id: int,
+    run_attempt: int,
+    head_sha: str,
+) -> str:
+    return "\n".join(
+        [
+            f"Tool ref: {tool_ref}",
+            f"Tool version: {tool_version}",
+            f"Workflow run: {run_id} attempt {run_attempt}",
+            f"PR head commit: {head_sha}",
+        ]
+    )
+
+
 def _wrap_markdown_code_block(text: str) -> str:
+    return _wrap_code_block(text, info_string="markdown")
+
+
+def _wrap_code_block(text: str, *, info_string: str | None = None) -> str:
     fence = "```"
     if fence in text:
         alternative = "~~~"
@@ -567,7 +584,8 @@ def _wrap_markdown_code_block(text: str) -> str:
         else:
             while fence in text:
                 fence += "`"
-    return f"{fence}markdown\n{text}\n{fence}"
+    opening = f"{fence}{info_string}" if info_string else fence
+    return f"{opening}\n{text}\n{fence}"
 
 
 def _format_percent(value: float) -> str:

--- a/tests/fixtures/prompts/expected_comment.md
+++ b/tests/fixtures/prompts/expected_comment.md
@@ -1,12 +1,7 @@
 <!-- pr-agent-context:managed-comment; schema=v3; pr=17; run_id=0; run_attempt=1; head_sha=def456; tool_ref=v3 -->
+pr-agent-context report:
 ```markdown
 Repository: foldermix
-
-Run metadata:
-- Tool ref: v3
-- Tool version: 3.0.0
-- Workflow run: 0 attempt 1
-- PR head commit: def456
 
 Below are the details of possibly unresolved review comments and/or (possibly) failing checks on PR
 #17.
@@ -78,4 +73,11 @@ Excerpt:
         assert func() == 3
     AssertionError
     ##[error]Process completed with exit code 1.
+```
+Run metadata:
+```
+Tool ref: v3
+Tool version: 3.0.0
+Workflow run: 0 attempt 1
+PR head commit: def456
 ```

--- a/tests/fixtures/prompts/expected_prompt.md
+++ b/tests/fixtures/prompts/expected_prompt.md
@@ -1,11 +1,5 @@
 Repository: foldermix
 
-Run metadata:
-- Tool ref: v3
-- Tool version: 3.0.0
-- Workflow run: 0 attempt 1
-- PR head commit: def456
-
 Below are the details of possibly unresolved review comments and/or (possibly) failing checks on PR
 #17.
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -88,10 +88,14 @@ def test_cli_run_publishes_failure_comment_and_returns_zero(monkeypatch, tmp_pat
     )
     assert "skipped_reason" not in comment_sync_event
     assert "error_status_code" not in comment_sync_event
+    assert captured["body"].startswith(
+        "<!-- pr-agent-context:managed-comment; schema=v3; pr=15; run_id=123; "
+    )
+    assert "\npr-agent-context report:\n```markdown\n" in captured["body"]
     assert "🚨 `pr-agent-context` failed while preparing PR context." in captured["body"]
-    assert "Head commit: deadbeef" in captured["body"]
-    assert "Version:" in captured["body"]
-    assert "run_attempt=2" in captured["body"].splitlines()[0]
+    assert "\nRun metadata:\n```\nTool ref: v3\nTool version:" in captured["body"]
+    assert "Workflow run: 123 attempt 2" in captured["body"]
+    assert "PR head commit: deadbeef" in captured["body"]
     assert captured["run_id"] == 123
     assert captured["run_attempt"] == 2
     outputs = Path(FakeConfig.github_output_path).read_text(encoding="utf-8")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -215,7 +215,7 @@ def test_render_prompt_renders_actionable_patch_coverage_section():
     )
 
     assert "# Codecov/patch" in rendered.prompt_markdown
-    assert "PR head commit: deadbeef" in rendered.prompt_markdown
+    assert "PR head commit: deadbeef" not in rendered.prompt_markdown
     assert "patch test coverage is 50%" in rendered.prompt_markdown
     assert "- src/pkg/example.py: 3, 4" in rendered.prompt_markdown
     assert rendered.has_actionable_items is True
@@ -240,7 +240,7 @@ def test_render_prompt_omits_patch_coverage_section_when_not_actionable():
     )
 
     assert "# Codecov/patch" not in rendered.prompt_markdown
-    assert "PR head commit: abc1234" in rendered.prompt_markdown
+    assert "PR head commit: abc1234" not in rendered.prompt_markdown
     assert "all clear" in rendered.prompt_markdown.lower()
     assert rendered.should_publish_comment is True
 
@@ -254,7 +254,7 @@ def test_render_prompt_renders_all_clear_message_when_nothing_is_actionable():
         patch_coverage=None,
     )
 
-    assert "PR head commit: feedface" in rendered.prompt_markdown
+    assert "PR head commit: feedface" not in rendered.prompt_markdown
     assert "all clear" in rendered.prompt_markdown.lower()
     assert "# Copilot Comments" not in rendered.prompt_markdown
     assert "# Failing Workflows" not in rendered.prompt_markdown
@@ -583,8 +583,10 @@ def test_render_prompt_uses_safe_outer_fence_when_markdown_contains_backticks(tm
     )
 
     assert rendered.comment_body.startswith("<!-- pr-agent-context:managed-comment; schema=v3;")
+    assert "pr-agent-context report:\n" in rendered.comment_body
     assert "\n~~~markdown" in rendered.comment_body
-    assert rendered.comment_body.endswith("\n~~~")
+    assert "\nRun metadata:\n```\nTool ref: v3\n" in rendered.comment_body
+    assert rendered.comment_body.endswith("\n```")
 
 
 def test_build_managed_comment_body_includes_run_scoped_marker():
@@ -602,6 +604,8 @@ def test_build_managed_comment_body_includes_run_scoped_marker():
         == "<!-- pr-agent-context:managed-comment; schema=v3; pr=17; run_id=123; "
         "run_attempt=4; head_sha=deadbeef; tool_ref=v3 -->"
     )
+    assert body.splitlines()[1] == "pr-agent-context report:"
+    assert "Run metadata:\n```\nTool ref: v3" in body
 
 
 def test_wrap_markdown_code_block_chooses_unique_fence():

--- a/tests/test_run_scoped_contract.py
+++ b/tests/test_run_scoped_contract.py
@@ -17,11 +17,11 @@ from pr_agent_context.domain.models import (
 def test_run_scoped_constants_expose_v3_marker_contract():
     assert MANAGED_COMMENT_MARKER_PREFIX == "<!-- pr-agent-context:managed-comment"
     assert MANAGED_COMMENT_SCHEMA_VERSION == "v3"
-    assert "{run_id}" in DEFAULT_PROMPT_OPENING
-    assert "{run_attempt}" in DEFAULT_PROMPT_OPENING
-    assert "{tool_ref}" in DEFAULT_PROMPT_OPENING
-    assert "{tool_version}" in DEFAULT_PROMPT_OPENING
-    assert "{run_id}" in DEFAULT_ALL_CLEAR_PROMPT
+    assert "{run_id}" not in DEFAULT_PROMPT_OPENING
+    assert "{run_attempt}" not in DEFAULT_PROMPT_OPENING
+    assert "{tool_ref}" not in DEFAULT_PROMPT_OPENING
+    assert "{tool_version}" not in DEFAULT_PROMPT_OPENING
+    assert "{run_id}" not in DEFAULT_ALL_CLEAR_PROMPT
     assert "{{ failing_checks_section }}" in DEFAULT_PROMPT_TEMPLATE
 
 

--- a/tests/test_run_service.py
+++ b/tests/test_run_service.py
@@ -674,4 +674,6 @@ def test_run_service_writes_debug_artifacts(tmp_path, issue_comments_payload):
     assert comment_sync["sync_debug"]["matched_existing_comment"] is False
     assert prompt_text.startswith("Repository: foldermix")
     assert comment_body.startswith("<!-- pr-agent-context:managed-comment; schema=v3;")
+    assert "pr-agent-context report:\n```markdown\nRepository: foldermix" in comment_body
+    assert "\nRun metadata:\n```\nTool ref: v3\n" in comment_body
     assert (config.debug_artifacts_dir / "comment-sync.json").exists()


### PR DESCRIPTION
## Summary
- add a visible `pr-agent-context report:` header outside the copied agent prompt block
- move run metadata out of the prompt and into a separate footer code block for all successful and failure comments
- update prompt snapshots, CLI fallback assertions, and README docs for the new outer comment layout

## Testing
- `pytest -q tests/test_render.py -k 'matches_expected_snapshots or build_managed_comment_body_includes_run_scoped_marker or uses_safe_outer_fence_when_markdown_contains_backticks'`
- `pytest -q tests/test_render.py tests/test_cli.py tests/test_run_service.py tests/test_run_scoped_contract.py` (printed only passing dots before the repo's known local end-of-run hang)
- `ruff check src/pr_agent_context/prompt/render.py src/pr_agent_context/constants.py src/pr_agent_context/cli.py tests/test_render.py tests/test_cli.py tests/test_run_service.py tests/test_run_scoped_contract.py README.md`
- `ruff format --check src/pr_agent_context/prompt/render.py src/pr_agent_context/constants.py src/pr_agent_context/cli.py tests/test_render.py tests/test_cli.py tests/test_run_service.py tests/test_run_scoped_contract.py`
