### PR TITLE
Pin self CI to v4.0.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,9 @@ jobs:
       contents: read
       actions: read
       pull-requests: write
-    uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4
+    uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4.0.3
     with:
-      tool_ref: v4
+      tool_ref: v4.0.3
       target_patch_coverage: "100"
       include_review_comments: true
       include_failing_checks: true


### PR DESCRIPTION
## Summary
- pin this repo's own `pr-agent-context` reusable workflow usage to `@v4.0.3`
- set `tool_ref: v4.0.3` in the self-repo CI caller workflow

## Notes
- this only changes the repo's own CI consumer workflow in `.github/workflows/ci.yml`
- examples and README still intentionally show the stable `@v4` major line for downstream users