### PR TITLE
Add a refresh workflow for pr-agent-context

### DIFF
--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -12,8 +12,7 @@ concurrency:
   group: >-
     ${{ github.workflow }}-${{
       github.event.pull_request.number ||
-      github.event.pull_request_review.pull_request.number ||
-      github.event.pull_request_review_comment.pull_request.number ||
+      github.event.check_run.pull_requests[0].number ||
       github.event.check_run.head_sha ||
       github.sha
     }}
@@ -28,12 +27,15 @@ jobs:
   pr-agent-context-refresh:
     name: PR agent context refresh
     if: >-
-      github.event_name == 'pull_request_review' ||
-      github.event_name == 'pull_request_review_comment' ||
+      (github.event_name == 'pull_request_review' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
+      (github.event_name == 'pull_request_review_comment' &&
+       github.event.pull_request.head.repo.full_name == github.repository) ||
       (github.event_name == 'check_run' &&
        github.event.action == 'completed' &&
        github.event.check_run.app.slug != 'github-actions' &&
-       toJson(github.event.check_run.pull_requests) != '[]')
+       toJson(github.event.check_run.pull_requests) != '[]' &&
+       github.event.check_run.pull_requests[0].head.repo.full_name == github.repository)
     uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4
     with:
       tool_ref: v4


### PR DESCRIPTION
Closes #35.

## Summary
- add a dedicated `pr-agent-context-refresh` workflow for this repository's own PRs
- trigger refresh runs on review activity and late-arriving non-Actions check runs
- reuse prior CI coverage artifacts in refresh mode and suppress all-clear refresh comments by default

## Validation
- loaded `.github/workflows/pr-agent-context-refresh.yml` with `yaml.safe_load(...)`
- verified `execution_mode: refresh` and `coverage_source_workflows: CI` in the workflow