### PR TITLE
Treat pending refresh coverage as unavailable

### DIFF
--- a/src/pr_agent_context/coverage/artifacts.py
+++ b/src/pr_agent_context/coverage/artifacts.py
@@ -48,6 +48,7 @@ def resolve_coverage_files(
         "selected_run": None,
         "selected_artifacts": [],
         "resolution": "",
+        "coverage_source_pending": False,
         "warnings": [],
     }
 
@@ -72,9 +73,12 @@ def resolve_coverage_files(
         debug=debug,
     )
     if selected_run is None:
-        debug["resolution"] = (
-            "local_current_run_artifacts_fallback" if local_files else "no_suitable_coverage_source"
-        )
+        if local_files:
+            debug["resolution"] = "local_current_run_artifacts_fallback"
+        elif debug["coverage_source_pending"]:
+            debug["resolution"] = "coverage_source_pending"
+        else:
+            debug["resolution"] = "no_suitable_coverage_source"
         return local_files, debug
 
     destination_root = local_artifacts_dir or Path(
@@ -101,6 +105,7 @@ def resolve_coverage_files(
     debug["selected_run"] = {
         "id": selected_run["id"],
         "name": selected_run["name"],
+        "status": selected_run["status"],
         "conclusion": selected_run["conclusion"],
         "updated_at": selected_run["updated_at"],
     }
@@ -158,12 +163,15 @@ def _select_coverage_source_run(
     )[:max_candidate_runs]
 
     selected: dict[str, object] | None = None
+    pending_candidate_found = False
     for run in sorted_runs:
         run_name = str(run.get("name") or "")
+        status = str(run.get("status") or "")
         conclusion = str(run.get("conclusion") or "")
         record = {
             "id": int(run.get("id") or 0),
             "name": run_name,
+            "status": status,
             "conclusion": conclusion,
             "updated_at": str(run.get("updated_at") or ""),
             "accepted": False,
@@ -173,6 +181,11 @@ def _select_coverage_source_run(
         if workflow_names and run_name not in workflow_names:
             record["reasons"].append("workflow_name_filtered")
             debug["candidate_runs"].append(record)
+            continue
+        if status and status != "completed":
+            record["reasons"].append("not_completed_yet")
+            debug["candidate_runs"].append(record)
+            pending_candidate_found = True
             continue
         if conclusion not in allowed_conclusions:
             record["reasons"].append("conclusion_filtered")
@@ -210,10 +223,12 @@ def _select_coverage_source_run(
             selected = {
                 "id": int(run["id"]),
                 "name": run_name,
+                "status": status,
                 "conclusion": conclusion,
                 "updated_at": str(run.get("updated_at") or ""),
                 "matching_artifacts": record["matching_artifacts"],
             }
+    debug["coverage_source_pending"] = pending_candidate_found
     return selected
 
 

--- a/src/pr_agent_context/coverage/patch.py
+++ b/src/pr_agent_context/coverage/patch.py
@@ -23,6 +23,7 @@ class _CoverageScopeContext:
     source_entries: tuple[str, ...]
     source_packages: tuple[str, ...]
     has_coverage_artifacts: bool
+    coverage_source_pending: bool
     scope_strategy: str
     warnings: tuple[str, ...]
 
@@ -34,12 +35,25 @@ def compute_patch_coverage(
     coverage: Coverage,
     target_percent: float,
     has_coverage_artifacts: bool = False,
+    coverage_source_pending: bool = False,
 ) -> PatchCoverageSummary:
     scope_context = _build_scope_context(
         coverage=coverage,
         workspace=workspace,
         has_coverage_artifacts=has_coverage_artifacts,
+        coverage_source_pending=coverage_source_pending,
     )
+
+    if scope_context.coverage_source_pending:
+        return PatchCoverageSummary(
+            target_percent=target_percent,
+            actual_percent=None,
+            total_changed_executable_lines=0,
+            covered_changed_executable_lines=0,
+            files=[],
+            actionable=False,
+            is_na=True,
+        )
 
     file_gaps: list[CoverageFileGap] = []
     total_executable = 0
@@ -127,14 +141,17 @@ def describe_patch_coverage_scope(
     workspace: Path,
     coverage: Coverage,
     has_coverage_artifacts: bool,
+    coverage_source_pending: bool = False,
 ) -> dict[str, object]:
     scope_context = _build_scope_context(
         coverage=coverage,
         workspace=workspace,
         has_coverage_artifacts=has_coverage_artifacts,
+        coverage_source_pending=coverage_source_pending,
     )
     return {
         "has_coverage_artifacts": scope_context.has_coverage_artifacts,
+        "coverage_source_pending": scope_context.coverage_source_pending,
         "scope_strategy": scope_context.scope_strategy,
         "measured_file_count": len(scope_context.measured_paths),
         "measured_file_sample": list(scope_context.measured_paths[:10]),
@@ -185,6 +202,7 @@ def _build_scope_context(
     coverage: Coverage,
     workspace: Path,
     has_coverage_artifacts: bool,
+    coverage_source_pending: bool,
 ) -> _CoverageScopeContext:
     measured_files = set(coverage.get_data().measured_files())
     measured_map = {_normalize_compare_path(path, workspace): path for path in measured_files}
@@ -199,7 +217,13 @@ def _build_scope_context(
     )
     warnings: list[str] = []
 
-    if source_entries or source_packages:
+    if coverage_source_pending and not measured_paths:
+        scope_strategy = "coverage_source_pending"
+        warnings.append(
+            "Coverage for this head SHA is not available yet. "
+            "Patch coverage was treated as N/A instead of 0%."
+        )
+    elif source_entries or source_packages:
         scope_strategy = "explicit_config"
     elif inferred_source_roots:
         scope_strategy = "measured_root_inference"
@@ -225,6 +249,7 @@ def _build_scope_context(
         source_entries=source_entries,
         source_packages=source_packages,
         has_coverage_artifacts=has_coverage_artifacts,
+        coverage_source_pending=coverage_source_pending,
         scope_strategy=scope_strategy,
         warnings=tuple(warnings),
     )

--- a/src/pr_agent_context/services/run.py
+++ b/src/pr_agent_context/services/run.py
@@ -221,6 +221,7 @@ def run_service(config: RunConfig, *, client: GitHubApiClient | None = None) -> 
             selection_strategy=config.coverage_selection_strategy,
             max_candidate_runs=config.max_actions_runs,
         )
+        coverage_source_pending = bool((coverage_source_debug or {}).get("coverage_source_pending"))
         _log(
             "patch_inputs",
             enabled=config.include_patch_coverage,
@@ -246,6 +247,7 @@ def run_service(config: RunConfig, *, client: GitHubApiClient | None = None) -> 
             workspace=config.workspace,
             coverage=combined_coverage,
             has_coverage_artifacts=bool(coverage_files),
+            coverage_source_pending=coverage_source_pending,
         )
         coverage_source_debug = {
             **(coverage_source_debug or {}),
@@ -258,6 +260,7 @@ def run_service(config: RunConfig, *, client: GitHubApiClient | None = None) -> 
             "process_cwd": process_cwd,
             "combined_measured_file_count": patch_scope_debug["measured_file_count"],
             "combined_measured_file_sample": patch_scope_debug["measured_file_sample"],
+            "coverage_source_pending": patch_scope_debug["coverage_source_pending"],
             "inferred_source_roots": patch_scope_debug["inferred_source_roots"],
             "patch_scope_strategy": patch_scope_debug["scope_strategy"],
             "explicit_source": patch_scope_debug["explicit_source"],
@@ -270,6 +273,7 @@ def run_service(config: RunConfig, *, client: GitHubApiClient | None = None) -> 
             coverage=combined_coverage,
             target_percent=config.target_patch_coverage,
             has_coverage_artifacts=bool(coverage_files),
+            coverage_source_pending=coverage_source_pending,
         )
         _log(
             "patch_result",

--- a/tests/test_patch_coverage.py
+++ b/tests/test_patch_coverage.py
@@ -553,6 +553,39 @@ def test_compute_patch_coverage_is_na_when_artifacts_have_no_measured_files(tmp_
     ]
 
 
+def test_compute_patch_coverage_is_na_when_coverage_source_is_pending(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source_path = repo / "src" / "pkg" / "module.py"
+    _write_file(source_path, "def branch(flag):\n    if flag:\n        return 1\n    return 2\n")
+    combined = build_combined_coverage(workspace=repo, coverage_files=[])
+
+    summary = compute_patch_coverage(
+        workspace=repo,
+        changed_lines_by_file={"src/pkg/module.py": [1, 2, 3, 4]},
+        coverage=combined,
+        target_percent=100,
+        has_coverage_artifacts=False,
+        coverage_source_pending=True,
+    )
+    scope_debug = describe_patch_coverage_scope(
+        workspace=repo,
+        coverage=combined,
+        has_coverage_artifacts=False,
+        coverage_source_pending=True,
+    )
+
+    assert summary.is_na is True
+    assert summary.actual_percent is None
+    assert summary.actionable is False
+    assert scope_debug["coverage_source_pending"] is True
+    assert scope_debug["scope_strategy"] == "coverage_source_pending"
+    assert scope_debug["warnings"] == [
+        "Coverage for this head SHA is not available yet. "
+        "Patch coverage was treated as N/A instead of 0%."
+    ]
+
+
 def test_build_combined_coverage_honors_relative_files_from_workspace_root(tmp_path, monkeypatch):
     job_workspace = tmp_path / "workspace"
     repo = job_workspace / "caller-repo"
@@ -685,6 +718,7 @@ def test_resolve_coverage_files_selects_latest_successful_matching_workflow(tmp_
     assert debug["selected_run"] == {
         "id": 30,
         "name": "CI",
+        "status": "",
         "conclusion": "success",
         "updated_at": "2026-03-10T12:00:00Z",
     }
@@ -728,6 +762,45 @@ def test_resolve_coverage_files_reports_missing_suitable_producer_run(tmp_path):
     assert debug["resolution"] == "no_suitable_coverage_source"
     assert debug["selected_run"] is None
     assert debug["candidate_runs"][0]["reasons"] == ["no_matching_artifacts"]
+
+
+def test_resolve_coverage_files_reports_pending_matching_producer_run(tmp_path):
+    client = CoverageSourceClient(
+        workflow_runs={
+            "workflow_runs": [
+                {
+                    "id": 30,
+                    "name": "CI",
+                    "status": "in_progress",
+                    "conclusion": None,
+                    "updated_at": "2026-03-10T12:00:00Z",
+                }
+            ]
+        },
+        artifacts_by_run={},
+        zip_bytes_by_artifact={},
+    )
+
+    files, debug = resolve_coverage_files(
+        client=client,
+        owner="shaypal5",
+        repo="example",
+        head_sha="deadbeef",
+        local_artifacts_dir=None,
+        artifact_prefix="pr-agent-context-coverage",
+        enable_cross_run_lookup=True,
+        execution_mode="refresh",
+        workflow_names=("CI",),
+        allowed_conclusions=("success",),
+        selection_strategy="latest_successful",
+        max_candidate_runs=20,
+    )
+
+    assert files == []
+    assert debug["resolution"] == "coverage_source_pending"
+    assert debug["coverage_source_pending"] is True
+    assert debug["selected_run"] is None
+    assert debug["candidate_runs"][0]["reasons"] == ["not_completed_yet"]
 
 
 def test_discover_coverage_files_ignores_transient_sqlite_sidecars(tmp_path):
@@ -799,6 +872,35 @@ def test_resolve_coverage_files_returns_local_files_when_cross_run_lookup_disabl
 
     assert files == [local_file]
     assert debug["resolution"] == "cross_run_lookup_disabled"
+
+
+def test_resolve_coverage_files_falls_back_to_local_files_when_no_cross_run_source_exists(tmp_path):
+    local_dir = tmp_path / "artifacts"
+    local_dir.mkdir()
+    local_file = local_dir / ".coverage.py312"
+    local_file.write_text("local", encoding="utf-8")
+
+    files, debug = resolve_coverage_files(
+        client=CoverageSourceClient(
+            workflow_runs={"workflow_runs": []},
+            artifacts_by_run={},
+            zip_bytes_by_artifact={},
+        ),
+        owner="shaypal5",
+        repo="example",
+        head_sha="deadbeef",
+        local_artifacts_dir=local_dir,
+        artifact_prefix="pr-agent-context-coverage",
+        enable_cross_run_lookup=True,
+        execution_mode="refresh",
+        workflow_names=("CI",),
+        allowed_conclusions=("success",),
+        selection_strategy="latest_successful",
+        max_candidate_runs=20,
+    )
+
+    assert files == [local_file]
+    assert debug["resolution"] == "local_current_run_artifacts_fallback"
 
 
 def test_resolve_coverage_files_reports_selected_run_without_coverage_files(tmp_path):

--- a/tests/test_run_service.py
+++ b/tests/test_run_service.py
@@ -784,6 +784,95 @@ def test_run_service_writes_coverage_source_debug_when_patch_coverage_enabled(
     assert "process_cwd" in coverage_source
 
 
+def test_run_service_refresh_mode_suppresses_pending_patch_coverage_section(
+    tmp_path, issue_comments_payload, monkeypatch
+):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    source_path = repo / "src" / "pkg" / "module.py"
+    _write_file(source_path, "def branch(flag):\n    if flag:\n        return 1\n    return 2\n")
+
+    empty_review_threads = {
+        "data": {
+            "repository": {
+                "pullRequest": {
+                    "reviewThreads": {
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                        "nodes": [],
+                    }
+                }
+            }
+        }
+    }
+    client = FakeGitHubClient(
+        review_threads_payload=empty_review_threads,
+        workflow_jobs_payload={"jobs": []},
+        issue_comments_payload=[issue_comments_payload[0]],
+    )
+    config = RunConfig(
+        github_token="token",
+        pull_request=PullRequestRef(
+            owner="shaypal5",
+            repo="example",
+            number=17,
+            base_sha="base123",
+            head_sha="deadbeef",
+        ),
+        run_id=1,
+        run_attempt=1,
+        workspace=repo,
+        execution_mode="refresh",
+        include_review_comments=False,
+        include_failing_checks=False,
+        include_patch_coverage=True,
+        coverage_artifacts_dir=tmp_path / "missing-artifacts",
+        debug_artifacts=True,
+        debug_artifacts_dir=tmp_path / "debug",
+        publish_all_clear_comments_in_refresh=False,
+        delete_comment_when_empty=True,
+        skip_comment_on_readonly_token=True,
+        github_output_path=tmp_path / "github-output.txt",
+    )
+
+    monkeypatch.setattr(
+        "pr_agent_context.services.run.collect_changed_lines",
+        lambda *_, **__: {"src/pkg/module.py": [1, 2, 3, 4]},
+    )
+    monkeypatch.setattr(
+        "pr_agent_context.services.run.resolve_coverage_files",
+        lambda **_: (
+            [],
+            {
+                "resolution": "coverage_source_pending",
+                "coverage_source_pending": True,
+                "candidate_runs": [{"id": 30, "reasons": ["not_completed_yet"]}],
+                "selected_run": None,
+                "selected_artifacts": [],
+                "warnings": [],
+            },
+        ),
+    )
+
+    assert run_service(config, client=client) == 0
+
+    coverage_source = json.loads(
+        (config.debug_artifacts_dir / "coverage-source.json").read_text(encoding="utf-8")
+    )
+    prompt_text = (config.debug_artifacts_dir / "prompt.md").read_text(encoding="utf-8")
+    comment_body = (config.debug_artifacts_dir / "comment-body.md").read_text(encoding="utf-8")
+    outputs = _read_outputs(config.github_output_path)
+
+    assert coverage_source["resolution"] == "coverage_source_pending"
+    assert coverage_source["coverage_source_pending"] is True
+    assert coverage_source["patch_scope_strategy"] == "coverage_source_pending"
+    assert outputs["has_actionable_items"] == "false"
+    assert outputs["patch_coverage_percent"] == ""
+    assert "# Codecov/patch" not in prompt_text
+    assert "Codecov shows patch test coverage is 0%" not in prompt_text
+    assert "# Codecov/patch" not in comment_body
+    assert client.created_bodies == []
+
+
 def test_run_service_excludes_changed_tests_for_cli_only_patch_coverage(
     tmp_path,
     issue_comments_payload,


### PR DESCRIPTION
## Summary
- classify refresh-mode coverage sources as pending when a matching producer run exists but is not completed yet
- treat pending coverage as `N/A` instead of falling back to false `0%` patch coverage
- add regressions for the PR #45 timing shape and the updated coverage-source debug output

## Verification
- `pytest tests/test_patch_coverage.py tests/test_run_service.py -q`
- `ruff check src/pr_agent_context/coverage/artifacts.py src/pr_agent_context/coverage/patch.py src/pr_agent_context/services/run.py tests/test_patch_coverage.py tests/test_run_service.py`
- `pytest -q`
- `pytest --cov=src/pr_agent_context --cov-branch --cov-report=term-missing -q`