### PR TITLE
Enable failed step output in self-consumer workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,7 @@ jobs:
       target_patch_coverage: "100"
       include_review_comments: true
       include_failing_checks: true
+      include_failed_step_output: true
       include_patch_coverage: true
       coverage_artifact_prefix: pr-agent-context-coverage
       debug_artifacts: true

--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -45,6 +45,7 @@ jobs:
       target_patch_coverage: "100"
       include_review_comments: true
       include_failing_checks: true
+      include_failed_step_output: true
       include_patch_coverage: true
       wait_for_reviews_to_settle: true
       coverage_artifact_prefix: pr-agent-context-coverage


### PR DESCRIPTION
## Summary
- enable `include_failed_step_output: true` in the repo's CI self-consumer workflow
- enable `include_failed_step_output: true` in the repo's refresh self-consumer workflow
- keep the change scoped to repo-local workflow usage of the reusable `pr-agent-context` workflow

## Verification
- parsed `.github/workflows/ci.yml`
- parsed `.github/workflows/pr-agent-context-refresh.yml`