### PR TITLE
Preserve Copilot comments in legacy prompt templates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,4 +78,5 @@ jobs:
       include_failed_step_output: true
       include_patch_coverage: true
       coverage_artifact_prefix: pr-agent-context-coverage
+      coverage_source_workflows: CI
       debug_artifacts: true

--- a/README.md
+++ b/README.md
@@ -197,6 +197,11 @@ Example custom template file:
 `prompt_preamble`, when non-empty, is always inserted near the top in a deterministic way,
 even if a custom template omits the explicit placeholder.
 
+If a custom template omits `{{ copilot_comments_section }}` but still includes
+`{{ review_comments_section }}`, `pr-agent-context` folds Copilot comments into the review
+comments placeholder to preserve compatibility with templates created before the split between
+Copilot and non-Copilot review sections.
+
 When `include_approval_gated_actions_run_notes` is enabled, custom templates should include
 `{{ approval_gated_actions_run_notes_section }}` if they want to control where the informational
 approval-gated section appears. If the placeholder is omitted, `pr-agent-context` appends that

--- a/skills/prompt-template-evolution/SKILL.md
+++ b/skills/prompt-template-evolution/SKILL.md
@@ -21,6 +21,7 @@ Use this playbook when the rendered prompt contract changes in `pr-agent-context
 
 ## Placement Rules
 - If a section is optional but should still render when enabled, document what happens when a custom template omits its placeholder.
+- Preserve backward compatibility for older templates when a section is split into multiple placeholders. For example, if Copilot comments move into their own placeholder, legacy templates that still render the generic review-comments placeholder should continue to surface them deterministically.
 - Keep the default behavior deterministic and explicitly describe fallback placement in docs.
 - Treat template-contract changes as API changes for downstream consumers.
 

--- a/src/pr_agent_context/prompt/render.py
+++ b/src/pr_agent_context/prompt/render.py
@@ -435,9 +435,7 @@ def _build_review_comments_template_value(
         and "copilot_comments_section" not in placeholders
         and "review_comments_section" in placeholders
     ):
-        return "\n\n".join(
-            section for section in (copilot_section, review_section) if section
-        )
+        return "\n\n".join(section for section in (copilot_section, review_section) if section)
     return review_section
 
 

--- a/src/pr_agent_context/prompt/render.py
+++ b/src/pr_agent_context/prompt/render.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import hashlib
-import re
 from pathlib import Path
 
 from pr_agent_context import __version__
@@ -34,9 +33,11 @@ from pr_agent_context.domain.models import (
 )
 from pr_agent_context.github.comment_markers import format_managed_comment_marker
 from pr_agent_context.prompt.line_wrap import wrap_markdown_prose
-from pr_agent_context.prompt.template import load_prompt_template, render_prompt_template
-
-_PLACEHOLDER_RE = re.compile(r"{{\s*([A-Za-z_][A-Za-z0-9_-]*)\s*}}")
+from pr_agent_context.prompt.template import (
+    PLACEHOLDER_RE,
+    load_prompt_template,
+    render_prompt_template,
+)
 from pr_agent_context.prompt.truncate import truncate_lines, truncate_text
 
 
@@ -429,7 +430,7 @@ def _build_review_comments_template_value(
     review_section: str,
     template_text: str,
 ) -> str:
-    placeholders = set(_PLACEHOLDER_RE.findall(template_text))
+    placeholders = set(PLACEHOLDER_RE.findall(template_text))
     if (
         copilot_section
         and "copilot_comments_section" not in placeholders

--- a/src/pr_agent_context/prompt/render.py
+++ b/src/pr_agent_context/prompt/render.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import hashlib
+import re
 from pathlib import Path
 
 from pr_agent_context import __version__
@@ -34,6 +35,8 @@ from pr_agent_context.domain.models import (
 from pr_agent_context.github.comment_markers import format_managed_comment_marker
 from pr_agent_context.prompt.line_wrap import wrap_markdown_prose
 from pr_agent_context.prompt.template import load_prompt_template, render_prompt_template
+
+_PLACEHOLDER_RE = re.compile(r"{{\s*([A-Za-z_][A-Za-z0-9_-]*)\s*}}")
 from pr_agent_context.prompt.truncate import truncate_lines, truncate_text
 
 
@@ -129,7 +132,11 @@ def render_prompt(
                 include_refresh_metadata=include_refresh_metadata,
             ),
             "copilot_comments_section": copilot_section,
-            "review_comments_section": review_section,
+            "review_comments_section": _build_review_comments_template_value(
+                copilot_section=copilot_section,
+                review_section=review_section,
+                template_text=template_text,
+            ),
             "failing_checks_section": failing_section,
             "approval_gated_actions_run_notes_section": approval_gated_actions_runs_section,
             "patch_coverage_section": patch_section,
@@ -414,6 +421,24 @@ def _render_review_threads_section(
     if note:
         notes.append(note)
     return trimmed, notes
+
+
+def _build_review_comments_template_value(
+    *,
+    copilot_section: str,
+    review_section: str,
+    template_text: str,
+) -> str:
+    placeholders = set(_PLACEHOLDER_RE.findall(template_text))
+    if (
+        copilot_section
+        and "copilot_comments_section" not in placeholders
+        and "review_comments_section" in placeholders
+    ):
+        return "\n\n".join(
+            section for section in (copilot_section, review_section) if section
+        )
+    return review_section
 
 
 def _render_review_thread(

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -854,9 +854,8 @@ def test_render_prompt_folds_copilot_comments_into_legacy_review_section(tmp_pat
     assert "## COPILOT-1" in rendered.prompt_markdown
     assert "# Other Review Comments" in rendered.prompt_markdown
     assert "## REVIEW-1" in rendered.prompt_markdown
-    assert (
-        rendered.prompt_markdown.index("# Copilot Comments")
-        < rendered.prompt_markdown.index("# Other Review Comments")
+    assert rendered.prompt_markdown.index("# Copilot Comments") < rendered.prompt_markdown.index(
+        "# Other Review Comments"
     )
 
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -832,6 +832,34 @@ def test_render_prompt_supports_custom_template_file(tmp_path):
     assert "# Other Review Comments" in rendered.prompt_markdown
 
 
+def test_render_prompt_folds_copilot_comments_into_legacy_review_section(tmp_path):
+    template = tmp_path / "template.md"
+    template.write_text(
+        "# PR {{ pr_number }}\n\n{{ prompt_preamble }}\n\n{{ review_comments_section }}",
+        encoding="utf-8",
+    )
+
+    rendered = render_prompt(
+        pull_request_number=17,
+        review_threads=[
+            _sample_review_thread(item_id="COPILOT-1", classifier="copilot"),
+            _sample_review_thread(item_id="REVIEW-1", classifier="review"),
+        ],
+        failing_checks=[],
+        prompt_preamble="Repository: example",
+        prompt_template_file=template,
+    )
+
+    assert "# Copilot Comments" in rendered.prompt_markdown
+    assert "## COPILOT-1" in rendered.prompt_markdown
+    assert "# Other Review Comments" in rendered.prompt_markdown
+    assert "## REVIEW-1" in rendered.prompt_markdown
+    assert (
+        rendered.prompt_markdown.index("# Copilot Comments")
+        < rendered.prompt_markdown.index("# Other Review Comments")
+    )
+
+
 def test_render_prompt_rejects_unknown_template_placeholders(tmp_path):
     template = tmp_path / "template.md"
     template.write_text("{{ unsupported_placeholder }}", encoding="utf-8")

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -859,6 +859,29 @@ def test_render_prompt_folds_copilot_comments_into_legacy_review_section(tmp_pat
     )
 
 
+def test_render_prompt_keeps_explicit_copilot_section_separate(tmp_path):
+    template = tmp_path / "template.md"
+    template.write_text(
+        "# PR {{ pr_number }}\n\n{{ copilot_comments_section }}\n\n{{ review_comments_section }}",
+        encoding="utf-8",
+    )
+
+    rendered = render_prompt(
+        pull_request_number=17,
+        review_threads=[
+            _sample_review_thread(item_id="COPILOT-1", classifier="copilot"),
+            _sample_review_thread(item_id="REVIEW-1", classifier="review"),
+        ],
+        failing_checks=[],
+        prompt_template_file=template,
+    )
+
+    assert rendered.prompt_markdown.count("# Copilot Comments") == 1
+    assert rendered.prompt_markdown.count("## COPILOT-1") == 1
+    assert rendered.prompt_markdown.count("# Other Review Comments") == 1
+    assert rendered.prompt_markdown.count("## REVIEW-1") == 1
+
+
 def test_render_prompt_rejects_unknown_template_placeholders(tmp_path):
     template = tmp_path / "template.md"
     template.write_text("{{ unsupported_placeholder }}", encoding="utf-8")


### PR DESCRIPTION
## Summary
- preserve Copilot review comments when a custom template still uses only `review_comments_section`
- add a regression test for legacy downstream templates that omit `copilot_comments_section`
- document the backward-compatibility fallback in the README and local template-evolution playbook

## Testing
- `pytest -q tests/test_render.py`