### PR TITLE
Bump version to 4.0.18

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pr-agent-context"
-version = "4.0.17"
+version = "4.0.18"
 description = "Reusable GitHub Actions tool for assembling PR handoff context for coding agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/fixtures/prompts/expected_comment.md
+++ b/tests/fixtures/prompts/expected_comment.md
@@ -75,7 +75,7 @@ Excerpt:
 Run metadata:
 ```
 Tool ref: v4
-Tool version: 4.0.17
+Tool version: 4.0.18
 Trigger: pull request updated
 Workflow run: 0 attempt 1
 Comment timestamp: unknown

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -15,7 +15,7 @@ def test_version_falls_back_to_pyproject_when_package_metadata_is_unavailable(
 
     reloaded = importlib.reload(package)
 
-    assert reloaded.__version__ == "4.0.17"
+    assert reloaded.__version__ == "4.0.18"
 
 
 def test_read_pyproject_version_reads_from_source_checkout(tmp_path, monkeypatch):
@@ -74,7 +74,7 @@ def test_github_api_client_defaults_user_agent_from_package_version():
 
     client = GitHubApiClient(token="token")
 
-    assert client._user_agent == "pr-agent-context/4.0.17"
+    assert client._user_agent == "pr-agent-context/4.0.18"
 
 
 def test_github_api_client_respects_explicit_user_agent_override():


### PR DESCRIPTION
## Summary
- bump the package version from `4.0.17` to `4.0.18`
- update the version expectations in `tests/test_version.py`
- refresh the expected rendered comment fixture so the reported tool version matches

## Validation
- `pytest tests/test_version.py tests/test_render.py -q`
- `ruff check tests/test_version.py`

## Notes
- This release bump PR intentionally updates exactly these files:
  - `pyproject.toml`
  - `tests/test_version.py`
  - `tests/fixtures/prompts/expected_comment.md`
- I left the untracked local `uv.lock` out of the branch.