### PR TITLE
Harden refresh delivery flow for approval-gated review events

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -2,6 +2,8 @@
 
 Follow [`AGENTS.md`](../AGENTS.md) for repo rules and update ripple checks.
 
+- Treat implementation work as incomplete until a non-draft GitHub PR with a detailed description is open and labeled appropriately.
 - For release/version bump work, consult [`skills/release-flow/SKILL.md`](../skills/release-flow/SKILL.md).
 - For downstream/client repo integration, refresh workflow behavior, or patch coverage wiring/debugging, consult [`skills/downstream-integration/SKILL.md`](../skills/downstream-integration/SKILL.md).
+- For finishing feature work and publishing the final PR, consult [`skills/pr-delivery/SKILL.md`](../skills/pr-delivery/SKILL.md).
 - When changing reusable workflow inputs or rendered comment metadata, keep README docs, examples, fixtures, and self-consumer workflows aligned.

--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -57,14 +57,23 @@ on:
 
 concurrency:
   group: >-
-    ${{ github.workflow }}-${{
-      github.event.pull_request.number ||
-      github.event.inputs.pull_request_number ||
-      github.event.check_run.pull_requests[0].number ||
-      github.event.inputs.pull_request_head_sha ||
-      github.event.check_run.head_sha ||
-      github.ref_name ||
-      github.sha
+    ${{
+      github.event_name == 'workflow_dispatch' &&
+      format(
+        '{0}-{1}-{2}',
+        github.workflow,
+        github.event.inputs.pull_request_number,
+        github.event.inputs.pull_request_head_sha
+      ) ||
+      format(
+        '{0}-{1}',
+        github.workflow,
+        github.event.pull_request.number ||
+        github.event.check_run.pull_requests[0].number ||
+        github.event.check_run.head_sha ||
+        github.ref_name ||
+        github.sha
+      )
     }}
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
@@ -103,12 +112,17 @@ jobs:
             let errorCount = 0;
             const recentDispatchWindowMs = 60 * 60 * 1000;
 
-            const workflowDispatchRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
+            const recentDispatchCutoff = Date.now() - recentDispatchWindowMs;
+            const { data: workflowRunsResponse } = await github.rest.actions.listWorkflowRuns({
               owner,
               repo,
               workflow_id: 'pr-agent-context-refresh.yml',
               event: 'workflow_dispatch',
               per_page: 100,
+            });
+            const workflowDispatchRuns = workflowRunsResponse.workflow_runs.filter((run) => {
+              const createdTimestamp = run.created_at ? Date.parse(run.created_at) : 0;
+              return createdTimestamp >= recentDispatchCutoff || run.status !== 'completed';
             });
 
             const hasCurrentRefreshComment = async (pull) => {

--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -1,4 +1,25 @@
 name: pr-agent-context-refresh
+run-name: >-
+  ${{
+    github.event_name == 'workflow_dispatch' &&
+    format(
+      'scheduled refresh PR #{0} @ {1}',
+      github.event.inputs.pull_request_number,
+      github.event.inputs.pull_request_head_sha
+    ) ||
+    github.event_name == 'schedule' &&
+    'scheduled refresh fanout' ||
+    github.event_name == 'pull_request_review' &&
+    format('review refresh PR #{0}', github.event.pull_request.number) ||
+    github.event_name == 'pull_request_review_comment' &&
+    format('review-comment refresh PR #{0}', github.event.pull_request.number) ||
+    github.event_name == 'check_run' &&
+    format(
+      'check refresh {0}',
+      github.event.check_run.pull_requests[0].number || github.event.check_run.head_sha
+    ) ||
+    github.workflow
+  }}
 
 on:
   pull_request_review:
@@ -80,6 +101,15 @@ jobs:
             let dispatchCount = 0;
             let skipCount = 0;
             let errorCount = 0;
+            const recentDispatchWindowMs = 60 * 60 * 1000;
+
+            const workflowDispatchRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner,
+              repo,
+              workflow_id: 'pr-agent-context-refresh.yml',
+              event: 'workflow_dispatch',
+              per_page: 100,
+            });
 
             const hasCurrentRefreshComment = async (pull) => {
               const { data: comments } = await github.rest.issues.listComments({
@@ -99,13 +129,41 @@ jobs:
               );
             };
 
+            const hasRecentOrInFlightScheduledDispatchRun = (pull) => {
+              const expectedTitle = `scheduled refresh PR #${pull.number} @ ${pull.head.sha}`;
+              const now = Date.now();
+
+              return workflowDispatchRuns.some((run) => {
+                if (run.display_title !== expectedTitle) {
+                  return false;
+                }
+                if (run.status !== 'completed') {
+                  return true;
+                }
+                const completedTimestamp = run.updated_at
+                  ? new Date(run.updated_at).getTime()
+                  : run.created_at
+                    ? new Date(run.created_at).getTime()
+                    : 0;
+                return completedTimestamp > 0 && now - completedTimestamp <= recentDispatchWindowMs;
+              });
+            };
+
             for (const pull of sameRepoPulls) {
               try {
                 const refreshCommentExists = await hasCurrentRefreshComment(pull);
+                const hasRecentDispatchRun = hasRecentOrInFlightScheduledDispatchRun(pull);
 
                 if (refreshCommentExists) {
                   core.notice(
                     `Skipping PR #${pull.number}: refresh comment for head ${pull.head.sha} already exists.`,
+                  );
+                  skipCount += 1;
+                  continue;
+                }
+                if (hasRecentDispatchRun) {
+                  core.notice(
+                    `Skipping PR #${pull.number}: recent or in-flight scheduled dispatch for head ${pull.head.sha} already exists.`,
                   );
                   skipCount += 1;
                   continue;

--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -7,12 +7,40 @@ on:
     types: [created, edited, deleted]
   check_run:
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: Pull request number to refresh explicitly.
+        required: true
+        type: string
+      pull_request_base_sha:
+        description: Base SHA for the explicit refresh target.
+        required: true
+        type: string
+      pull_request_head_sha:
+        description: Head SHA for the explicit refresh target.
+        required: true
+        type: string
+      trigger_event_name:
+        description: Synthetic trigger event name used in rendered metadata.
+        required: false
+        default: workflow_dispatch
+        type: string
+      trigger_event_action:
+        description: Synthetic trigger event action used in rendered metadata.
+        required: false
+        default: ""
+        type: string
+  schedule:
+    - cron: "*/15 * * * *"
 
 concurrency:
   group: >-
     ${{ github.workflow }}-${{
       github.event.pull_request.number ||
+      github.event.inputs.pull_request_number ||
       github.event.check_run.pull_requests[0].number ||
+      github.event.inputs.pull_request_head_sha ||
       github.event.check_run.head_sha ||
       github.sha
     }}
@@ -24,22 +52,75 @@ permissions:
   pull-requests: write
 
 jobs:
+  dispatch-scheduled-refreshes:
+    name: Dispatch scheduled refreshes
+    if: ${{ github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+      pull-requests: read
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const sameRepoPulls = pulls.filter(
+              (pull) => pull.head?.repo?.full_name === `${owner}/${repo}`,
+            );
+
+            core.notice(`Dispatching ${sameRepoPulls.length} refresh run(s).`);
+
+            for (const pull of sameRepoPulls) {
+              await github.rest.actions.createWorkflowDispatch({
+                owner,
+                repo,
+                workflow_id: 'pr-agent-context-refresh.yml',
+                ref: context.ref.replace('refs/heads/', ''),
+                inputs: {
+                  pull_request_number: String(pull.number),
+                  pull_request_base_sha: pull.base.sha,
+                  pull_request_head_sha: pull.head.sha,
+                  trigger_event_name: 'schedule',
+                  trigger_event_action: '',
+                },
+              });
+            }
+
   pr-agent-context-refresh:
     name: PR agent context refresh
     if: >-
-      (github.event_name == 'pull_request_review' &&
-       github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_review_comment' &&
-       github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'check_run' &&
-       github.event.action == 'completed' &&
-       github.event.check_run.app.slug != 'github-actions' &&
-       toJson(github.event.check_run.pull_requests) != '[]' &&
-       github.event.check_run.pull_requests[0].head.repo.full_name == github.repository)
+      github.event_name != 'schedule' &&
+      (
+        (github.event_name == 'pull_request_review' &&
+         github.event.pull_request.head.repo.full_name == github.repository) ||
+        (github.event_name == 'pull_request_review_comment' &&
+         github.event.pull_request.head.repo.full_name == github.repository) ||
+        (github.event_name == 'check_run' &&
+         github.event.action == 'completed' &&
+         github.event.check_run.app.slug != 'github-actions' &&
+         toJson(github.event.check_run.pull_requests) != '[]' &&
+         github.event.check_run.pull_requests[0].head.repo.full_name == github.repository) ||
+        (github.event_name == 'workflow_dispatch' &&
+         github.event.inputs.pull_request_number != '' &&
+         github.event.inputs.pull_request_base_sha != '' &&
+         github.event.inputs.pull_request_head_sha != '')
+      )
     uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4
     with:
       tool_ref: v4
       execution_mode: refresh
+      trigger_event_name_override: ${{ github.event.inputs.trigger_event_name || '' }}
+      trigger_event_action_override: ${{ github.event.inputs.trigger_event_action || '' }}
+      pull_request_number_override: ${{ github.event.inputs.pull_request_number || '' }}
+      pull_request_base_sha_override: ${{ github.event.inputs.pull_request_base_sha || '' }}
+      pull_request_head_sha_override: ${{ github.event.inputs.pull_request_head_sha || '' }}
       publish_mode: append
       publish_all_clear_comments_in_refresh: false
       target_patch_coverage: "100"

--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -113,7 +113,7 @@ jobs:
             const recentDispatchWindowMs = 60 * 60 * 1000;
 
             const recentDispatchCutoff = Date.now() - recentDispatchWindowMs;
-            const { data: workflowRunsResponse } = await github.rest.actions.listWorkflowRuns({
+            const { data: workflowRunsResponse } = await github.rest.actions.listWorkflowRunsForWorkflow({
               owner,
               repo,
               workflow_id: 'pr-agent-context-refresh.yml',

--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -45,7 +45,7 @@ concurrency:
       github.ref_name ||
       github.sha
     }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 permissions:
   contents: read
@@ -76,9 +76,41 @@ jobs:
               (pull) => pull.head?.repo?.full_name === `${owner}/${repo}`,
             );
 
-            core.notice(`Dispatching ${sameRepoPulls.length} refresh run(s).`);
+            const markerPrefix = '<!-- pr-agent-context:managed-comment;';
+            let dispatchCount = 0;
+            let skipCount = 0;
 
             for (const pull of sameRepoPulls) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: pull.number,
+                per_page: 100,
+              });
+              const matchingRefreshComments = comments
+                .filter((comment) => comment.body?.startsWith(markerPrefix))
+                .filter((comment) => comment.body.includes('execution_mode=refresh;'))
+                .filter((comment) => comment.body.includes(`head_sha=${pull.head.sha};`))
+                .sort(
+                  (left, right) =>
+                    new Date(right.created_at).getTime() - new Date(left.created_at).getTime(),
+                );
+              const latestRefreshComment = matchingRefreshComments[0];
+              const latestRefreshTimestamp = latestRefreshComment
+                ? new Date(latestRefreshComment.created_at).getTime()
+                : 0;
+              const pullUpdatedTimestamp = pull.updated_at
+                ? new Date(pull.updated_at).getTime()
+                : 0;
+
+              if (latestRefreshComment && latestRefreshTimestamp >= pullUpdatedTimestamp) {
+                core.notice(
+                  `Skipping PR #${pull.number}: refresh comment for head ${pull.head.sha} is current.`,
+                );
+                skipCount += 1;
+                continue;
+              }
+
               await github.rest.actions.createWorkflowDispatch({
                 owner,
                 repo,
@@ -92,7 +124,12 @@ jobs:
                   trigger_event_action: '',
                 },
               });
+              dispatchCount += 1;
             }
+
+            core.notice(
+              `Scheduled refresh guard dispatched ${dispatchCount} run(s) and skipped ${skipCount}.`,
+            );
 
   pr-agent-context-refresh:
     name: PR agent context refresh

--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -79,57 +79,66 @@ jobs:
             const markerPrefix = '<!-- pr-agent-context:managed-comment;';
             let dispatchCount = 0;
             let skipCount = 0;
+            let errorCount = 0;
 
-            for (const pull of sameRepoPulls) {
-              const comments = await github.paginate(github.rest.issues.listComments, {
+            const hasCurrentRefreshComment = async (pull) => {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner,
                 repo,
                 issue_number: pull.number,
-                per_page: 100,
+                per_page: 50,
+                sort: 'created',
+                direction: 'desc',
               });
-              const matchingRefreshComments = comments
-                .filter((comment) => comment.body?.startsWith(markerPrefix))
-                .filter((comment) => comment.body.includes('execution_mode=refresh;'))
-                .filter((comment) => comment.body.includes(`head_sha=${pull.head.sha};`))
-                .sort(
-                  (left, right) =>
-                    new Date(right.created_at).getTime() - new Date(left.created_at).getTime(),
-                );
-              const latestRefreshComment = matchingRefreshComments[0];
-              const latestRefreshTimestamp = latestRefreshComment
-                ? new Date(latestRefreshComment.created_at).getTime()
-                : 0;
-              const pullUpdatedTimestamp = pull.updated_at
-                ? new Date(pull.updated_at).getTime()
-                : 0;
 
-              if (latestRefreshComment && latestRefreshTimestamp >= pullUpdatedTimestamp) {
-                core.notice(
-                  `Skipping PR #${pull.number}: refresh comment for head ${pull.head.sha} is current.`,
+              return comments.some(
+                (comment) =>
+                  comment.body?.startsWith(markerPrefix) &&
+                  comment.body.includes('execution_mode=refresh;') &&
+                  comment.body.includes(`head_sha=${pull.head.sha};`),
+              );
+            };
+
+            for (const pull of sameRepoPulls) {
+              try {
+                const refreshCommentExists = await hasCurrentRefreshComment(pull);
+
+                if (refreshCommentExists) {
+                  core.notice(
+                    `Skipping PR #${pull.number}: refresh comment for head ${pull.head.sha} already exists.`,
+                  );
+                  skipCount += 1;
+                  continue;
+                }
+
+                await github.rest.actions.createWorkflowDispatch({
+                  owner,
+                  repo,
+                  workflow_id: 'pr-agent-context-refresh.yml',
+                  ref: context.ref.replace('refs/heads/', ''),
+                  inputs: {
+                    pull_request_number: String(pull.number),
+                    pull_request_base_sha: pull.base.sha,
+                    pull_request_head_sha: pull.head.sha,
+                    trigger_event_name: 'schedule',
+                    trigger_event_action: '',
+                  },
+                });
+                dispatchCount += 1;
+              } catch (error) {
+                errorCount += 1;
+                core.warning(
+                  `Unable to evaluate or dispatch PR #${pull.number}: ${error instanceof Error ? error.message : String(error)}`,
                 );
-                skipCount += 1;
-                continue;
               }
-
-              await github.rest.actions.createWorkflowDispatch({
-                owner,
-                repo,
-                workflow_id: 'pr-agent-context-refresh.yml',
-                ref: context.ref.replace('refs/heads/', ''),
-                inputs: {
-                  pull_request_number: String(pull.number),
-                  pull_request_base_sha: pull.base.sha,
-                  pull_request_head_sha: pull.head.sha,
-                  trigger_event_name: 'schedule',
-                  trigger_event_action: '',
-                },
-              });
-              dispatchCount += 1;
             }
 
             core.notice(
               `Scheduled refresh guard dispatched ${dispatchCount} run(s) and skipped ${skipCount}.`,
             );
+            if (errorCount > 0) {
+              core.warning(`Scheduled refresh guard encountered ${errorCount} per-PR error(s).`);
+            }
 
   pr-agent-context-refresh:
     name: PR agent context refresh

--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -42,6 +42,7 @@ concurrency:
       github.event.check_run.pull_requests[0].number ||
       github.event.inputs.pull_request_head_sha ||
       github.event.check_run.head_sha ||
+      github.ref_name ||
       github.sha
     }}
   cancel-in-progress: true

--- a/.github/workflows/pr-agent-context.yml
+++ b/.github/workflows/pr-agent-context.yml
@@ -345,8 +345,8 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           PR_AGENT_CONTEXT_TOOL_REF: ${{ inputs.tool_ref }}
           PR_AGENT_CONTEXT_EXECUTION_MODE: ${{ inputs.execution_mode }}
-          PR_AGENT_CONTEXT_TRIGGER_EVENT_NAME: ${{ inputs.trigger_event_name_override }}
-          PR_AGENT_CONTEXT_TRIGGER_EVENT_ACTION: ${{ inputs.trigger_event_action_override }}
+          PR_AGENT_CONTEXT_TRIGGER_EVENT_NAME: ${{ inputs.trigger_event_name_override != '' && inputs.trigger_event_name_override || github.event_name }}
+          PR_AGENT_CONTEXT_TRIGGER_EVENT_ACTION: ${{ inputs.trigger_event_action_override != '' && inputs.trigger_event_action_override || github.event.action }}
           PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number_override }}
           PR_AGENT_CONTEXT_BASE_SHA: ${{ inputs.pull_request_base_sha_override }}
           PR_AGENT_CONTEXT_HEAD_SHA: ${{ inputs.pull_request_head_sha_override }}

--- a/.github/workflows/pr-agent-context.yml
+++ b/.github/workflows/pr-agent-context.yml
@@ -13,6 +13,31 @@ on:
         required: false
         default: auto
         type: string
+      trigger_event_name_override:
+        description: Optional explicit trigger event name for dispatch- or schedule-driven refreshes.
+        required: false
+        default: ""
+        type: string
+      trigger_event_action_override:
+        description: Optional explicit trigger event action paired with trigger_event_name_override.
+        required: false
+        default: ""
+        type: string
+      pull_request_number_override:
+        description: Optional explicit pull request number for dispatch- or schedule-driven refreshes.
+        required: false
+        default: ""
+        type: string
+      pull_request_base_sha_override:
+        description: Optional explicit pull request base SHA for dispatch- or schedule-driven refreshes.
+        required: false
+        default: ""
+        type: string
+      pull_request_head_sha_override:
+        description: Optional explicit pull request head SHA for dispatch- or schedule-driven refreshes.
+        required: false
+        default: ""
+        type: string
       publish_mode:
         description: append, update_latest_managed, update_matching, or update_latest_scoped.
         required: false
@@ -320,6 +345,11 @@ jobs:
           GITHUB_TOKEN: ${{ github.token }}
           PR_AGENT_CONTEXT_TOOL_REF: ${{ inputs.tool_ref }}
           PR_AGENT_CONTEXT_EXECUTION_MODE: ${{ inputs.execution_mode }}
+          PR_AGENT_CONTEXT_TRIGGER_EVENT_NAME: ${{ inputs.trigger_event_name_override }}
+          PR_AGENT_CONTEXT_TRIGGER_EVENT_ACTION: ${{ inputs.trigger_event_action_override }}
+          PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER: ${{ inputs.pull_request_number_override }}
+          PR_AGENT_CONTEXT_BASE_SHA: ${{ inputs.pull_request_base_sha_override }}
+          PR_AGENT_CONTEXT_HEAD_SHA: ${{ inputs.pull_request_head_sha_override }}
           PR_AGENT_CONTEXT_PUBLISH_MODE: ${{ inputs.publish_mode }}
           PR_AGENT_CONTEXT_INCLUDE_REFRESH_METADATA: ${{ inputs.include_refresh_metadata }}
           PR_AGENT_CONTEXT_WORKSPACE: ${{ github.workspace }}/caller-repo

--- a/.github/workflows/pr-agent-context.yml
+++ b/.github/workflows/pr-agent-context.yml
@@ -397,8 +397,6 @@ jobs:
           PR_AGENT_CONTEXT_SKIP_COMMENT_ON_READONLY_TOKEN: ${{ inputs.skip_comment_on_readonly_token }}
           PR_AGENT_CONTEXT_COVERAGE_ARTIFACTS_DIR: ${{ github.workspace }}/coverage-artifacts
           PR_AGENT_CONTEXT_DEBUG_ARTIFACTS_DIR: ${{ github.workspace }}/pr-agent-context-debug
-          PR_AGENT_CONTEXT_TRIGGER_EVENT_NAME: ${{ github.event_name }}
-          PR_AGENT_CONTEXT_TRIGGER_EVENT_ACTION: ${{ github.event.action }}
         run: pr-agent-context run
 
       - name: Upload debug artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,7 @@
 - Start every new feature, milestone, bugfix, or other non-trivial implementation branch from up-to-date `main`.
 - Before beginning new implementation work, update local `main` from `origin/main` and branch from that refreshed tip.
 - Do not continue new work on an already-merged feature branch unless the user explicitly asks for that.
+- Treat feature or PR work as incomplete until a non-draft GitHub PR is open from the working branch with a detailed description, appropriate labels, and a milestone when one applies.
 
 ## Repo Playbook
 
@@ -22,6 +23,7 @@
 - CI runs may publish an all-clear comment.
 - Refresh runs should default to append-mode comment history and suppress no-op all-clear comments.
 - The current recommended refresh pattern is `publish_mode: append` with `publish_all_clear_comments_in_refresh: false`.
+- If bot-authored review events can leave refresh runs stuck in approval, prefer a repo-owned `schedule` -> `workflow_dispatch` fallback that passes explicit PR context overrides.
 
 ### Update Ripple Checklist
 - If you change reusable workflow inputs, config parsing, or environment variable handling, update the README input docs, examples, config tests, and this repo's self-consumer workflows when relevant.
@@ -37,6 +39,12 @@
 - After the release PR is merged, tag the merged `main` commit with `vX.Y.Z`.
 - Let `release-tags.yml` move the `v4` major tag; do not retag a PR branch tip.
 
+### PR Completion
+- For feature, fix, and release-PR work, do not stop at local commits.
+- Push the branch and open a non-draft PR on GitHub with a detailed description before considering the task done, unless the user explicitly says not to.
+- Apply repository-appropriate labels and assign a milestone when one fits the work.
+- If the required label or milestone does not exist yet, create it.
+
 ### GitHub Tooling
 - Keep using the repo-specific git and GitHub MCPs first.
 - Use `gh api` only for gaps the MCPs do not cover yet, such as resolving review threads.
@@ -47,3 +55,4 @@
 - For managed comment publication behavior and append/update mode decisions, consult [`skills/comment-publishing/SKILL.md`](skills/comment-publishing/SKILL.md).
 - For downstream/client repo integration or patch-coverage wiring/debugging, consult [`skills/downstream-integration/SKILL.md`](skills/downstream-integration/SKILL.md).
 - For prompt template and rendered-section changes, consult [`skills/prompt-template-evolution/SKILL.md`](skills/prompt-template-evolution/SKILL.md).
+- For finishing feature work and publishing a ready PR, consult [`skills/pr-delivery/SKILL.md`](skills/pr-delivery/SKILL.md).

--- a/README.md
+++ b/README.md
@@ -327,6 +327,7 @@ concurrency:
       github.event.check_run.pull_requests[0].number ||
       github.event.inputs.pull_request_head_sha ||
       github.event.check_run.head_sha ||
+      github.ref_name ||
       github.sha
     }}
   cancel-in-progress: true

--- a/README.md
+++ b/README.md
@@ -91,6 +91,16 @@ The reusable workflow inputs are:
 - `execution_mode`: controls whether the run behaves like the initial CI pass or a later refresh
   pass. `ci` always uses CI behavior, `refresh` always uses refresh behavior, and `auto`
   infers the mode from the triggering event, default `auto`
+- `trigger_event_name_override`: optional explicit trigger event name for dispatch- or
+  schedule-driven refreshes, default `""`
+- `trigger_event_action_override`: optional explicit trigger event action paired with
+  `trigger_event_name_override`, default `""`
+- `pull_request_number_override`: optional explicit pull request number for dispatch- or
+  schedule-driven refreshes, default `""`
+- `pull_request_base_sha_override`: optional explicit pull request base SHA for dispatch- or
+  schedule-driven refreshes, default `""`
+- `pull_request_head_sha_override`: optional explicit pull request head SHA for dispatch- or
+  schedule-driven refreshes, default `""`
 - `publish_mode`: controls how managed PR comments are created or updated, default `append`
   - `append`: when the run publishes a managed comment, post it as a new PR comment instead of
     updating an existing one; by default, older `pr-agent-context` managed comments on the same
@@ -242,6 +252,9 @@ Recommended minimal caller-side pattern:
 2. Refresh workflow
 - triggers: `pull_request_review`, `pull_request_review_comment`
 - optional additional triggers: `workflow_run`, `status`, `check_run`, `check_suite`
+- optional hardening: add a repo-owned `schedule` plus `workflow_dispatch` path that fans out
+  explicit PR refreshes when bot-authored review events would otherwise leave runs stuck waiting
+  for approval
 - invokes the same reusable workflow with:
   - `execution_mode: refresh`
   - `publish_mode: append`
@@ -260,6 +273,8 @@ For production use, prefer a refresh workflow with:
 - concurrency per PR so rapid review/check bursts coalesce
 - `coverage_source_workflows` pinned to the CI producer workflow name when refresh runs reuse
   earlier coverage artifacts
+- a repo-owned scheduled dispatcher if Copilot or other bot-authored review events can leave
+  direct refresh runs waiting for maintainer approval
 
 Status-driven refreshes can arrive after a PR is closed or merged. In those cases,
 `pr-agent-context` resolves the PR from the trigger SHA and preserves the trigger head SHA for
@@ -277,12 +292,40 @@ on:
     types: [created, edited, deleted]
   check_run:
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: Pull request number to refresh explicitly.
+        required: true
+        type: string
+      pull_request_base_sha:
+        description: Base SHA for the explicit refresh target.
+        required: true
+        type: string
+      pull_request_head_sha:
+        description: Head SHA for the explicit refresh target.
+        required: true
+        type: string
+      trigger_event_name:
+        description: Synthetic trigger event name used in rendered metadata.
+        required: false
+        default: workflow_dispatch
+        type: string
+      trigger_event_action:
+        description: Synthetic trigger event action used in rendered metadata.
+        required: false
+        default: ""
+        type: string
+  schedule:
+    - cron: "*/15 * * * *"
 
 concurrency:
   group: >-
     ${{ github.workflow }}-${{
       github.event.pull_request.number ||
+      github.event.inputs.pull_request_number ||
       github.event.check_run.pull_requests[0].number ||
+      github.event.inputs.pull_request_head_sha ||
       github.event.check_run.head_sha ||
       github.sha
     }}
@@ -294,21 +337,74 @@ permissions:
   pull-requests: write
 
 jobs:
+  dispatch-scheduled-refreshes:
+    name: Dispatch scheduled refreshes
+    if: ${{ github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+      pull-requests: read
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const sameRepoPulls = pulls.filter(
+              (pull) => pull.head?.repo?.full_name === `${owner}/${repo}`,
+            );
+
+            core.notice(`Dispatching ${sameRepoPulls.length} refresh run(s).`);
+
+            for (const pull of sameRepoPulls) {
+              await github.rest.actions.createWorkflowDispatch({
+                owner,
+                repo,
+                workflow_id: 'pr-agent-context-refresh.yml',
+                ref: context.ref.replace('refs/heads/', ''),
+                inputs: {
+                  pull_request_number: String(pull.number),
+                  pull_request_base_sha: pull.base.sha,
+                  pull_request_head_sha: pull.head.sha,
+                  trigger_event_name: 'schedule',
+                  trigger_event_action: '',
+                },
+              });
+            }
+
   pr-agent-context:
     if: >-
-      (github.event_name == 'pull_request_review' &&
-       github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_review_comment' &&
-       github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'check_run' &&
-       github.event.action == 'completed' &&
-       github.event.check_run.app.slug != 'github-actions' &&
-       toJson(github.event.check_run.pull_requests) != '[]' &&
-       github.event.check_run.pull_requests[0].head.repo.full_name == github.repository)
+      github.event_name != 'schedule' &&
+      (
+        (github.event_name == 'pull_request_review' &&
+         github.event.pull_request.head.repo.full_name == github.repository) ||
+        (github.event_name == 'pull_request_review_comment' &&
+         github.event.pull_request.head.repo.full_name == github.repository) ||
+        (github.event_name == 'check_run' &&
+         github.event.action == 'completed' &&
+         github.event.check_run.app.slug != 'github-actions' &&
+         toJson(github.event.check_run.pull_requests) != '[]' &&
+         github.event.check_run.pull_requests[0].head.repo.full_name == github.repository) ||
+        (github.event_name == 'workflow_dispatch' &&
+         github.event.inputs.pull_request_number != '' &&
+         github.event.inputs.pull_request_base_sha != '' &&
+         github.event.inputs.pull_request_head_sha != '')
+      )
     uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4
     with:
       tool_ref: v4
       execution_mode: refresh
+      trigger_event_name_override: ${{ github.event.inputs.trigger_event_name || '' }}
+      trigger_event_action_override: ${{ github.event.inputs.trigger_event_action || '' }}
+      pull_request_number_override: ${{ github.event.inputs.pull_request_number || '' }}
+      pull_request_base_sha_override: ${{ github.event.inputs.pull_request_base_sha || '' }}
+      pull_request_head_sha_override: ${{ github.event.inputs.pull_request_head_sha || '' }}
       publish_mode: append
       publish_all_clear_comments_in_refresh: false
       target_patch_coverage: "100"
@@ -337,6 +433,11 @@ Additional copy-pasteable examples live in [`examples/`](examples/):
 
 Refresh mode is best-effort on forks. When write access, external checks, or artifact access are
 restricted, the tool records those degradations in debug artifacts instead of failing wholesale.
+
+If Copilot or another bot can leave review-triggered refresh runs waiting for maintainer approval,
+the scheduled dispatcher pattern above avoids depending on that blocked run. The schedule wakes up
+as the repository itself, enumerates open same-repo PRs, and re-dispatches explicit refresh runs
+with `pull_request_*_override` inputs so `pr-agent-context` can still resolve the PR cleanly.
 
 ## Coverage Artifact Contract
 

--- a/README.md
+++ b/README.md
@@ -284,6 +284,27 @@ Production-hardened refresh workflow example:
 
 ```yaml
 name: pr-agent-context-refresh
+run-name: >-
+  ${{
+    github.event_name == 'workflow_dispatch' &&
+    format(
+      'scheduled refresh PR #{0} @ {1}',
+      github.event.inputs.pull_request_number,
+      github.event.inputs.pull_request_head_sha
+    ) ||
+    github.event_name == 'schedule' &&
+    'scheduled refresh fanout' ||
+    github.event_name == 'pull_request_review' &&
+    format('review refresh PR #{0}', github.event.pull_request.number) ||
+    github.event_name == 'pull_request_review_comment' &&
+    format('review-comment refresh PR #{0}', github.event.pull_request.number) ||
+    github.event_name == 'check_run' &&
+    format(
+      'check refresh {0}',
+      github.event.check_run.pull_requests[0].number || github.event.check_run.head_sha
+    ) ||
+    github.workflow
+  }}
 
 on:
   pull_request_review:
@@ -365,6 +386,15 @@ jobs:
             let dispatchCount = 0;
             let skipCount = 0;
             let errorCount = 0;
+            const recentDispatchWindowMs = 60 * 60 * 1000;
+
+            const workflowDispatchRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner,
+              repo,
+              workflow_id: 'pr-agent-context-refresh.yml',
+              event: 'workflow_dispatch',
+              per_page: 100,
+            });
 
             const hasCurrentRefreshComment = async (pull) => {
               const { data: comments } = await github.rest.issues.listComments({
@@ -384,13 +414,41 @@ jobs:
               );
             };
 
+            const hasRecentOrInFlightScheduledDispatchRun = (pull) => {
+              const expectedTitle = `scheduled refresh PR #${pull.number} @ ${pull.head.sha}`;
+              const now = Date.now();
+
+              return workflowDispatchRuns.some((run) => {
+                if (run.display_title !== expectedTitle) {
+                  return false;
+                }
+                if (run.status !== 'completed') {
+                  return true;
+                }
+                const completedTimestamp = run.updated_at
+                  ? new Date(run.updated_at).getTime()
+                  : run.created_at
+                    ? new Date(run.created_at).getTime()
+                    : 0;
+                return completedTimestamp > 0 && now - completedTimestamp <= recentDispatchWindowMs;
+              });
+            };
+
             for (const pull of sameRepoPulls) {
               try {
                 const refreshCommentExists = await hasCurrentRefreshComment(pull);
+                const hasRecentDispatchRun = hasRecentOrInFlightScheduledDispatchRun(pull);
 
                 if (refreshCommentExists) {
                   core.notice(
                     `Skipping PR #${pull.number}: refresh comment for head ${pull.head.sha} already exists.`,
+                  );
+                  skipCount += 1;
+                  continue;
+                }
+                if (hasRecentDispatchRun) {
+                  core.notice(
+                    `Skipping PR #${pull.number}: recent or in-flight scheduled dispatch for head ${pull.head.sha} already exists.`,
                   );
                   skipCount += 1;
                   continue;
@@ -483,10 +541,12 @@ restricted, the tool records those degradations in debug artifacts instead of fa
 
 If Copilot or another bot can leave review-triggered refresh runs waiting for maintainer approval,
 the scheduled dispatcher pattern above avoids depending on that blocked run. The schedule wakes up
-as the repository itself, enumerates open same-repo PRs, and performs a bounded lookup of recent
-PR comments before re-dispatching. If a same-head refresh managed comment already exists, it skips
-that PR; otherwise it dispatches explicit refresh runs with `pull_request_*_override` inputs so
-`pr-agent-context` can still resolve the PR cleanly.
+as the repository itself, enumerates open same-repo PRs, and uses a composite dedupe guard before
+re-dispatching: it first checks for a same-head refresh managed comment, then checks for a recent
+or in-flight scheduled `workflow_dispatch` run with the same PR number and head SHA. That second
+guard matters when refresh runs suppress all-clear comments, because a no-op refresh may otherwise
+leave no managed comment behind. Only when neither signal exists does it dispatch explicit refresh
+runs with `pull_request_*_override` inputs so `pr-agent-context` can still resolve the PR cleanly.
 
 ## Coverage Artifact Contract
 

--- a/README.md
+++ b/README.md
@@ -364,57 +364,66 @@ jobs:
             const markerPrefix = '<!-- pr-agent-context:managed-comment;';
             let dispatchCount = 0;
             let skipCount = 0;
+            let errorCount = 0;
 
-            for (const pull of sameRepoPulls) {
-              const comments = await github.paginate(github.rest.issues.listComments, {
+            const hasCurrentRefreshComment = async (pull) => {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner,
                 repo,
                 issue_number: pull.number,
-                per_page: 100,
+                per_page: 50,
+                sort: 'created',
+                direction: 'desc',
               });
-              const matchingRefreshComments = comments
-                .filter((comment) => comment.body?.startsWith(markerPrefix))
-                .filter((comment) => comment.body.includes('execution_mode=refresh;'))
-                .filter((comment) => comment.body.includes(`head_sha=${pull.head.sha};`))
-                .sort(
-                  (left, right) =>
-                    new Date(right.created_at).getTime() - new Date(left.created_at).getTime(),
-                );
-              const latestRefreshComment = matchingRefreshComments[0];
-              const latestRefreshTimestamp = latestRefreshComment
-                ? new Date(latestRefreshComment.created_at).getTime()
-                : 0;
-              const pullUpdatedTimestamp = pull.updated_at
-                ? new Date(pull.updated_at).getTime()
-                : 0;
 
-              if (latestRefreshComment && latestRefreshTimestamp >= pullUpdatedTimestamp) {
-                core.notice(
-                  `Skipping PR #${pull.number}: refresh comment for head ${pull.head.sha} is current.`,
+              return comments.some(
+                (comment) =>
+                  comment.body?.startsWith(markerPrefix) &&
+                  comment.body.includes('execution_mode=refresh;') &&
+                  comment.body.includes(`head_sha=${pull.head.sha};`),
+              );
+            };
+
+            for (const pull of sameRepoPulls) {
+              try {
+                const refreshCommentExists = await hasCurrentRefreshComment(pull);
+
+                if (refreshCommentExists) {
+                  core.notice(
+                    `Skipping PR #${pull.number}: refresh comment for head ${pull.head.sha} already exists.`,
+                  );
+                  skipCount += 1;
+                  continue;
+                }
+
+                await github.rest.actions.createWorkflowDispatch({
+                  owner,
+                  repo,
+                  workflow_id: 'pr-agent-context-refresh.yml',
+                  ref: context.ref.replace('refs/heads/', ''),
+                  inputs: {
+                    pull_request_number: String(pull.number),
+                    pull_request_base_sha: pull.base.sha,
+                    pull_request_head_sha: pull.head.sha,
+                    trigger_event_name: 'schedule',
+                    trigger_event_action: '',
+                  },
+                });
+                dispatchCount += 1;
+              } catch (error) {
+                errorCount += 1;
+                core.warning(
+                  `Unable to evaluate or dispatch PR #${pull.number}: ${error instanceof Error ? error.message : String(error)}`,
                 );
-                skipCount += 1;
-                continue;
               }
-
-              await github.rest.actions.createWorkflowDispatch({
-                owner,
-                repo,
-                workflow_id: 'pr-agent-context-refresh.yml',
-                ref: context.ref.replace('refs/heads/', ''),
-                inputs: {
-                  pull_request_number: String(pull.number),
-                  pull_request_base_sha: pull.base.sha,
-                  pull_request_head_sha: pull.head.sha,
-                  trigger_event_name: 'schedule',
-                  trigger_event_action: '',
-                },
-              });
-              dispatchCount += 1;
             }
 
             core.notice(
               `Scheduled refresh guard dispatched ${dispatchCount} run(s) and skipped ${skipCount}.`,
             );
+            if (errorCount > 0) {
+              core.warning(`Scheduled refresh guard encountered ${errorCount} per-PR error(s).`);
+            }
 
   pr-agent-context:
     if: >-
@@ -474,8 +483,10 @@ restricted, the tool records those degradations in debug artifacts instead of fa
 
 If Copilot or another bot can leave review-triggered refresh runs waiting for maintainer approval,
 the scheduled dispatcher pattern above avoids depending on that blocked run. The schedule wakes up
-as the repository itself, enumerates open same-repo PRs, and re-dispatches explicit refresh runs
-with `pull_request_*_override` inputs so `pr-agent-context` can still resolve the PR cleanly.
+as the repository itself, enumerates open same-repo PRs, and performs a bounded lookup of recent
+PR comments before re-dispatching. If a same-head refresh managed comment already exists, it skips
+that PR; otherwise it dispatches explicit refresh runs with `pull_request_*_override` inputs so
+`pr-agent-context` can still resolve the PR cleanly.
 
 ## Coverage Artifact Contract
 

--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ jobs:
             const recentDispatchWindowMs = 60 * 60 * 1000;
 
             const recentDispatchCutoff = Date.now() - recentDispatchWindowMs;
-            const { data: workflowRunsResponse } = await github.rest.actions.listWorkflowRuns({
+            const { data: workflowRunsResponse } = await github.rest.actions.listWorkflowRunsForWorkflow({
               owner,
               repo,
               workflow_id: 'pr-agent-context-refresh.yml',

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ concurrency:
       github.ref_name ||
       github.sha
     }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 permissions:
   contents: read
@@ -361,9 +361,41 @@ jobs:
               (pull) => pull.head?.repo?.full_name === `${owner}/${repo}`,
             );
 
-            core.notice(`Dispatching ${sameRepoPulls.length} refresh run(s).`);
+            const markerPrefix = '<!-- pr-agent-context:managed-comment;';
+            let dispatchCount = 0;
+            let skipCount = 0;
 
             for (const pull of sameRepoPulls) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: pull.number,
+                per_page: 100,
+              });
+              const matchingRefreshComments = comments
+                .filter((comment) => comment.body?.startsWith(markerPrefix))
+                .filter((comment) => comment.body.includes('execution_mode=refresh;'))
+                .filter((comment) => comment.body.includes(`head_sha=${pull.head.sha};`))
+                .sort(
+                  (left, right) =>
+                    new Date(right.created_at).getTime() - new Date(left.created_at).getTime(),
+                );
+              const latestRefreshComment = matchingRefreshComments[0];
+              const latestRefreshTimestamp = latestRefreshComment
+                ? new Date(latestRefreshComment.created_at).getTime()
+                : 0;
+              const pullUpdatedTimestamp = pull.updated_at
+                ? new Date(pull.updated_at).getTime()
+                : 0;
+
+              if (latestRefreshComment && latestRefreshTimestamp >= pullUpdatedTimestamp) {
+                core.notice(
+                  `Skipping PR #${pull.number}: refresh comment for head ${pull.head.sha} is current.`,
+                );
+                skipCount += 1;
+                continue;
+              }
+
               await github.rest.actions.createWorkflowDispatch({
                 owner,
                 repo,
@@ -377,7 +409,12 @@ jobs:
                   trigger_event_action: '',
                 },
               });
+              dispatchCount += 1;
             }
+
+            core.notice(
+              `Scheduled refresh guard dispatched ${dispatchCount} run(s) and skipped ${skipCount}.`,
+            );
 
   pr-agent-context:
     if: >-

--- a/README.md
+++ b/README.md
@@ -342,14 +342,23 @@ on:
 
 concurrency:
   group: >-
-    ${{ github.workflow }}-${{
-      github.event.pull_request.number ||
-      github.event.inputs.pull_request_number ||
-      github.event.check_run.pull_requests[0].number ||
-      github.event.inputs.pull_request_head_sha ||
-      github.event.check_run.head_sha ||
-      github.ref_name ||
-      github.sha
+    ${{
+      github.event_name == 'workflow_dispatch' &&
+      format(
+        '{0}-{1}-{2}',
+        github.workflow,
+        github.event.inputs.pull_request_number,
+        github.event.inputs.pull_request_head_sha
+      ) ||
+      format(
+        '{0}-{1}',
+        github.workflow,
+        github.event.pull_request.number ||
+        github.event.check_run.pull_requests[0].number ||
+        github.event.check_run.head_sha ||
+        github.ref_name ||
+        github.sha
+      )
     }}
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
@@ -388,12 +397,17 @@ jobs:
             let errorCount = 0;
             const recentDispatchWindowMs = 60 * 60 * 1000;
 
-            const workflowDispatchRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
+            const recentDispatchCutoff = Date.now() - recentDispatchWindowMs;
+            const { data: workflowRunsResponse } = await github.rest.actions.listWorkflowRuns({
               owner,
               repo,
               workflow_id: 'pr-agent-context-refresh.yml',
               event: 'workflow_dispatch',
               per_page: 100,
+            });
+            const workflowDispatchRuns = workflowRunsResponse.workflow_runs.filter((run) => {
+              const createdTimestamp = run.created_at ? Date.parse(run.created_at) : 0;
+              return createdTimestamp >= recentDispatchCutoff || run.status !== 'completed';
             });
 
             const hasCurrentRefreshComment = async (pull) => {

--- a/examples/pr-agent-context-refresh.yml
+++ b/examples/pr-agent-context-refresh.yml
@@ -57,14 +57,23 @@ on:
 
 concurrency:
   group: >-
-    ${{ github.workflow }}-${{
-      github.event.pull_request.number ||
-      github.event.inputs.pull_request_number ||
-      github.event.check_run.pull_requests[0].number ||
-      github.event.inputs.pull_request_head_sha ||
-      github.event.check_run.head_sha ||
-      github.ref_name ||
-      github.sha
+    ${{
+      github.event_name == 'workflow_dispatch' &&
+      format(
+        '{0}-{1}-{2}',
+        github.workflow,
+        github.event.inputs.pull_request_number,
+        github.event.inputs.pull_request_head_sha
+      ) ||
+      format(
+        '{0}-{1}',
+        github.workflow,
+        github.event.pull_request.number ||
+        github.event.check_run.pull_requests[0].number ||
+        github.event.check_run.head_sha ||
+        github.ref_name ||
+        github.sha
+      )
     }}
   cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
@@ -103,12 +112,17 @@ jobs:
             let errorCount = 0;
             const recentDispatchWindowMs = 60 * 60 * 1000;
 
-            const workflowDispatchRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
+            const recentDispatchCutoff = Date.now() - recentDispatchWindowMs;
+            const { data: workflowRunsResponse } = await github.rest.actions.listWorkflowRuns({
               owner,
               repo,
               workflow_id: 'pr-agent-context-refresh.yml',
               event: 'workflow_dispatch',
               per_page: 100,
+            });
+            const workflowDispatchRuns = workflowRunsResponse.workflow_runs.filter((run) => {
+              const createdTimestamp = run.created_at ? Date.parse(run.created_at) : 0;
+              return createdTimestamp >= recentDispatchCutoff || run.status !== 'completed';
             });
 
             const hasCurrentRefreshComment = async (pull) => {

--- a/examples/pr-agent-context-refresh.yml
+++ b/examples/pr-agent-context-refresh.yml
@@ -1,4 +1,25 @@
 name: pr-agent-context-refresh
+run-name: >-
+  ${{
+    github.event_name == 'workflow_dispatch' &&
+    format(
+      'scheduled refresh PR #{0} @ {1}',
+      github.event.inputs.pull_request_number,
+      github.event.inputs.pull_request_head_sha
+    ) ||
+    github.event_name == 'schedule' &&
+    'scheduled refresh fanout' ||
+    github.event_name == 'pull_request_review' &&
+    format('review refresh PR #{0}', github.event.pull_request.number) ||
+    github.event_name == 'pull_request_review_comment' &&
+    format('review-comment refresh PR #{0}', github.event.pull_request.number) ||
+    github.event_name == 'check_run' &&
+    format(
+      'check refresh {0}',
+      github.event.check_run.pull_requests[0].number || github.event.check_run.head_sha
+    ) ||
+    github.workflow
+  }}
 
 on:
   pull_request_review:
@@ -80,6 +101,15 @@ jobs:
             let dispatchCount = 0;
             let skipCount = 0;
             let errorCount = 0;
+            const recentDispatchWindowMs = 60 * 60 * 1000;
+
+            const workflowDispatchRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
+              owner,
+              repo,
+              workflow_id: 'pr-agent-context-refresh.yml',
+              event: 'workflow_dispatch',
+              per_page: 100,
+            });
 
             const hasCurrentRefreshComment = async (pull) => {
               const { data: comments } = await github.rest.issues.listComments({
@@ -99,13 +129,41 @@ jobs:
               );
             };
 
+            const hasRecentOrInFlightScheduledDispatchRun = (pull) => {
+              const expectedTitle = `scheduled refresh PR #${pull.number} @ ${pull.head.sha}`;
+              const now = Date.now();
+
+              return workflowDispatchRuns.some((run) => {
+                if (run.display_title !== expectedTitle) {
+                  return false;
+                }
+                if (run.status !== 'completed') {
+                  return true;
+                }
+                const completedTimestamp = run.updated_at
+                  ? new Date(run.updated_at).getTime()
+                  : run.created_at
+                    ? new Date(run.created_at).getTime()
+                    : 0;
+                return completedTimestamp > 0 && now - completedTimestamp <= recentDispatchWindowMs;
+              });
+            };
+
             for (const pull of sameRepoPulls) {
               try {
                 const refreshCommentExists = await hasCurrentRefreshComment(pull);
+                const hasRecentDispatchRun = hasRecentOrInFlightScheduledDispatchRun(pull);
 
                 if (refreshCommentExists) {
                   core.notice(
                     `Skipping PR #${pull.number}: refresh comment for head ${pull.head.sha} already exists.`,
+                  );
+                  skipCount += 1;
+                  continue;
+                }
+                if (hasRecentDispatchRun) {
+                  core.notice(
+                    `Skipping PR #${pull.number}: recent or in-flight scheduled dispatch for head ${pull.head.sha} already exists.`,
                   );
                   skipCount += 1;
                   continue;

--- a/examples/pr-agent-context-refresh.yml
+++ b/examples/pr-agent-context-refresh.yml
@@ -7,12 +7,40 @@ on:
     types: [created, edited, deleted]
   check_run:
     types: [completed]
+  workflow_dispatch:
+    inputs:
+      pull_request_number:
+        description: Pull request number to refresh explicitly.
+        required: true
+        type: string
+      pull_request_base_sha:
+        description: Base SHA for the explicit refresh target.
+        required: true
+        type: string
+      pull_request_head_sha:
+        description: Head SHA for the explicit refresh target.
+        required: true
+        type: string
+      trigger_event_name:
+        description: Synthetic trigger event name used in rendered metadata.
+        required: false
+        default: workflow_dispatch
+        type: string
+      trigger_event_action:
+        description: Synthetic trigger event action used in rendered metadata.
+        required: false
+        default: ""
+        type: string
+  schedule:
+    - cron: "*/15 * * * *"
 
 concurrency:
   group: >-
     ${{ github.workflow }}-${{
       github.event.pull_request.number ||
+      github.event.inputs.pull_request_number ||
       github.event.check_run.pull_requests[0].number ||
+      github.event.inputs.pull_request_head_sha ||
       github.event.check_run.head_sha ||
       github.sha
     }}
@@ -24,21 +52,74 @@ permissions:
   pull-requests: write
 
 jobs:
+  dispatch-scheduled-refreshes:
+    name: Dispatch scheduled refreshes
+    if: ${{ github.event_name == 'schedule' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      actions: write
+      pull-requests: read
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const pulls = await github.paginate(github.rest.pulls.list, {
+              owner,
+              repo,
+              state: 'open',
+              per_page: 100,
+            });
+            const sameRepoPulls = pulls.filter(
+              (pull) => pull.head?.repo?.full_name === `${owner}/${repo}`,
+            );
+
+            core.notice(`Dispatching ${sameRepoPulls.length} refresh run(s).`);
+
+            for (const pull of sameRepoPulls) {
+              await github.rest.actions.createWorkflowDispatch({
+                owner,
+                repo,
+                workflow_id: 'pr-agent-context-refresh.yml',
+                ref: context.ref.replace('refs/heads/', ''),
+                inputs: {
+                  pull_request_number: String(pull.number),
+                  pull_request_base_sha: pull.base.sha,
+                  pull_request_head_sha: pull.head.sha,
+                  trigger_event_name: 'schedule',
+                  trigger_event_action: '',
+                },
+              });
+            }
+
   pr-agent-context:
     if: >-
-      (github.event_name == 'pull_request_review' &&
-       github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'pull_request_review_comment' &&
-       github.event.pull_request.head.repo.full_name == github.repository) ||
-      (github.event_name == 'check_run' &&
-       github.event.action == 'completed' &&
-       github.event.check_run.app.slug != 'github-actions' &&
-       toJson(github.event.check_run.pull_requests) != '[]' &&
-       github.event.check_run.pull_requests[0].head.repo.full_name == github.repository)
+      github.event_name != 'schedule' &&
+      (
+        (github.event_name == 'pull_request_review' &&
+         github.event.pull_request.head.repo.full_name == github.repository) ||
+        (github.event_name == 'pull_request_review_comment' &&
+         github.event.pull_request.head.repo.full_name == github.repository) ||
+        (github.event_name == 'check_run' &&
+         github.event.action == 'completed' &&
+         github.event.check_run.app.slug != 'github-actions' &&
+         toJson(github.event.check_run.pull_requests) != '[]' &&
+         github.event.check_run.pull_requests[0].head.repo.full_name == github.repository) ||
+        (github.event_name == 'workflow_dispatch' &&
+         github.event.inputs.pull_request_number != '' &&
+         github.event.inputs.pull_request_base_sha != '' &&
+         github.event.inputs.pull_request_head_sha != '')
+      )
     uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4
     with:
       tool_ref: v4
       execution_mode: refresh
+      trigger_event_name_override: ${{ github.event.inputs.trigger_event_name || '' }}
+      trigger_event_action_override: ${{ github.event.inputs.trigger_event_action || '' }}
+      pull_request_number_override: ${{ github.event.inputs.pull_request_number || '' }}
+      pull_request_base_sha_override: ${{ github.event.inputs.pull_request_base_sha || '' }}
+      pull_request_head_sha_override: ${{ github.event.inputs.pull_request_head_sha || '' }}
       publish_mode: append
       publish_all_clear_comments_in_refresh: false
       target_patch_coverage: "100"

--- a/examples/pr-agent-context-refresh.yml
+++ b/examples/pr-agent-context-refresh.yml
@@ -45,7 +45,7 @@ concurrency:
       github.ref_name ||
       github.sha
     }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.event_name != 'workflow_dispatch' }}
 
 permissions:
   contents: read
@@ -76,9 +76,41 @@ jobs:
               (pull) => pull.head?.repo?.full_name === `${owner}/${repo}`,
             );
 
-            core.notice(`Dispatching ${sameRepoPulls.length} refresh run(s).`);
+            const markerPrefix = '<!-- pr-agent-context:managed-comment;';
+            let dispatchCount = 0;
+            let skipCount = 0;
 
             for (const pull of sameRepoPulls) {
+              const comments = await github.paginate(github.rest.issues.listComments, {
+                owner,
+                repo,
+                issue_number: pull.number,
+                per_page: 100,
+              });
+              const matchingRefreshComments = comments
+                .filter((comment) => comment.body?.startsWith(markerPrefix))
+                .filter((comment) => comment.body.includes('execution_mode=refresh;'))
+                .filter((comment) => comment.body.includes(`head_sha=${pull.head.sha};`))
+                .sort(
+                  (left, right) =>
+                    new Date(right.created_at).getTime() - new Date(left.created_at).getTime(),
+                );
+              const latestRefreshComment = matchingRefreshComments[0];
+              const latestRefreshTimestamp = latestRefreshComment
+                ? new Date(latestRefreshComment.created_at).getTime()
+                : 0;
+              const pullUpdatedTimestamp = pull.updated_at
+                ? new Date(pull.updated_at).getTime()
+                : 0;
+
+              if (latestRefreshComment && latestRefreshTimestamp >= pullUpdatedTimestamp) {
+                core.notice(
+                  `Skipping PR #${pull.number}: refresh comment for head ${pull.head.sha} is current.`,
+                );
+                skipCount += 1;
+                continue;
+              }
+
               await github.rest.actions.createWorkflowDispatch({
                 owner,
                 repo,
@@ -92,7 +124,12 @@ jobs:
                   trigger_event_action: '',
                 },
               });
+              dispatchCount += 1;
             }
+
+            core.notice(
+              `Scheduled refresh guard dispatched ${dispatchCount} run(s) and skipped ${skipCount}.`,
+            );
 
   pr-agent-context:
     if: >-

--- a/examples/pr-agent-context-refresh.yml
+++ b/examples/pr-agent-context-refresh.yml
@@ -79,57 +79,66 @@ jobs:
             const markerPrefix = '<!-- pr-agent-context:managed-comment;';
             let dispatchCount = 0;
             let skipCount = 0;
+            let errorCount = 0;
 
-            for (const pull of sameRepoPulls) {
-              const comments = await github.paginate(github.rest.issues.listComments, {
+            const hasCurrentRefreshComment = async (pull) => {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner,
                 repo,
                 issue_number: pull.number,
-                per_page: 100,
+                per_page: 50,
+                sort: 'created',
+                direction: 'desc',
               });
-              const matchingRefreshComments = comments
-                .filter((comment) => comment.body?.startsWith(markerPrefix))
-                .filter((comment) => comment.body.includes('execution_mode=refresh;'))
-                .filter((comment) => comment.body.includes(`head_sha=${pull.head.sha};`))
-                .sort(
-                  (left, right) =>
-                    new Date(right.created_at).getTime() - new Date(left.created_at).getTime(),
-                );
-              const latestRefreshComment = matchingRefreshComments[0];
-              const latestRefreshTimestamp = latestRefreshComment
-                ? new Date(latestRefreshComment.created_at).getTime()
-                : 0;
-              const pullUpdatedTimestamp = pull.updated_at
-                ? new Date(pull.updated_at).getTime()
-                : 0;
 
-              if (latestRefreshComment && latestRefreshTimestamp >= pullUpdatedTimestamp) {
-                core.notice(
-                  `Skipping PR #${pull.number}: refresh comment for head ${pull.head.sha} is current.`,
+              return comments.some(
+                (comment) =>
+                  comment.body?.startsWith(markerPrefix) &&
+                  comment.body.includes('execution_mode=refresh;') &&
+                  comment.body.includes(`head_sha=${pull.head.sha};`),
+              );
+            };
+
+            for (const pull of sameRepoPulls) {
+              try {
+                const refreshCommentExists = await hasCurrentRefreshComment(pull);
+
+                if (refreshCommentExists) {
+                  core.notice(
+                    `Skipping PR #${pull.number}: refresh comment for head ${pull.head.sha} already exists.`,
+                  );
+                  skipCount += 1;
+                  continue;
+                }
+
+                await github.rest.actions.createWorkflowDispatch({
+                  owner,
+                  repo,
+                  workflow_id: 'pr-agent-context-refresh.yml',
+                  ref: context.ref.replace('refs/heads/', ''),
+                  inputs: {
+                    pull_request_number: String(pull.number),
+                    pull_request_base_sha: pull.base.sha,
+                    pull_request_head_sha: pull.head.sha,
+                    trigger_event_name: 'schedule',
+                    trigger_event_action: '',
+                  },
+                });
+                dispatchCount += 1;
+              } catch (error) {
+                errorCount += 1;
+                core.warning(
+                  `Unable to evaluate or dispatch PR #${pull.number}: ${error instanceof Error ? error.message : String(error)}`,
                 );
-                skipCount += 1;
-                continue;
               }
-
-              await github.rest.actions.createWorkflowDispatch({
-                owner,
-                repo,
-                workflow_id: 'pr-agent-context-refresh.yml',
-                ref: context.ref.replace('refs/heads/', ''),
-                inputs: {
-                  pull_request_number: String(pull.number),
-                  pull_request_base_sha: pull.base.sha,
-                  pull_request_head_sha: pull.head.sha,
-                  trigger_event_name: 'schedule',
-                  trigger_event_action: '',
-                },
-              });
-              dispatchCount += 1;
             }
 
             core.notice(
               `Scheduled refresh guard dispatched ${dispatchCount} run(s) and skipped ${skipCount}.`,
             );
+            if (errorCount > 0) {
+              core.warning(`Scheduled refresh guard encountered ${errorCount} per-PR error(s).`);
+            }
 
   pr-agent-context:
     if: >-

--- a/examples/pr-agent-context-refresh.yml
+++ b/examples/pr-agent-context-refresh.yml
@@ -113,7 +113,7 @@ jobs:
             const recentDispatchWindowMs = 60 * 60 * 1000;
 
             const recentDispatchCutoff = Date.now() - recentDispatchWindowMs;
-            const { data: workflowRunsResponse } = await github.rest.actions.listWorkflowRuns({
+            const { data: workflowRunsResponse } = await github.rest.actions.listWorkflowRunsForWorkflow({
               owner,
               repo,
               workflow_id: 'pr-agent-context-refresh.yml',

--- a/examples/pr-agent-context-refresh.yml
+++ b/examples/pr-agent-context-refresh.yml
@@ -42,6 +42,7 @@ concurrency:
       github.event.check_run.pull_requests[0].number ||
       github.event.inputs.pull_request_head_sha ||
       github.event.check_run.head_sha ||
+      github.ref_name ||
       github.sha
     }}
   cancel-in-progress: true

--- a/memory/MEMORY.md
+++ b/memory/MEMORY.md
@@ -1,0 +1,5 @@
+# Agent Memory
+
+- In this repository, feature work is not complete until the branch is pushed and a non-draft GitHub PR is open with a detailed description.
+- Final PR hygiene includes applying the right labels and assigning a milestone when one applies to the work.
+- If the needed GitHub label or milestone does not exist yet, create it instead of leaving the PR partially configured.

--- a/skills/downstream-integration/SKILL.md
+++ b/skills/downstream-integration/SKILL.md
@@ -45,6 +45,8 @@ Use this playbook for client-repo adoption, refresh workflow fixes, and patch-co
   recent comments and skip redispatch when a same-head refresh managed comment already exists.
 - Avoid guards based on `pull.updated_at`, because managed comment publication can update that
   timestamp and create false redispatch signals.
+- If refresh runs suppress all-clear comments, add a second dedupe guard for recent or in-flight
+  scheduled `workflow_dispatch` runs keyed by the same PR number and head SHA.
 - Prefer keeping `cancel-in-progress` for direct event-triggered refreshes while disabling
   cancel-on-rerun for the scheduled `workflow_dispatch` fallback path.
 - Add per-PR error isolation in the scheduled dispatcher so one transient API failure does not

--- a/skills/downstream-integration/SKILL.md
+++ b/skills/downstream-integration/SKILL.md
@@ -41,10 +41,14 @@ Use this playbook for client-repo adoption, refresh workflow fixes, and patch-co
 - If Copilot or another bot can trigger approval-gated review events in the caller repo, add a
   repo-owned `schedule` job that redispatches the refresh workflow through `workflow_dispatch`
   with explicit PR number/base/head overrides.
-- Do not make that scheduled job blindly redispatch every open PR. Prefer a guard that checks
-  whether the latest same-head refresh comment is missing or stale before redispatching.
+- Do not make that scheduled job blindly redispatch every open PR. Prefer a bounded lookup of
+  recent comments and skip redispatch when a same-head refresh managed comment already exists.
+- Avoid guards based on `pull.updated_at`, because managed comment publication can update that
+  timestamp and create false redispatch signals.
 - Prefer keeping `cancel-in-progress` for direct event-triggered refreshes while disabling
   cancel-on-rerun for the scheduled `workflow_dispatch` fallback path.
+- Add per-PR error isolation in the scheduled dispatcher so one transient API failure does not
+  block the rest of the fanout.
 - Closed or merged PR refreshes can resolve from the trigger SHA; when debugging those paths,
   inspect `pull-request-context.json` before assuming GitHub returned the wrong PR.
 

--- a/skills/downstream-integration/SKILL.md
+++ b/skills/downstream-integration/SKILL.md
@@ -38,6 +38,9 @@ Use this playbook for client-repo adoption, refresh workflow fixes, and patch-co
 - Point `coverage_source_workflows` at the producer workflow name when refresh runs need to reuse earlier CI artifacts.
 - Prefer same-repo guards and per-PR concurrency in refresh workflows so comment mutation is
   limited to writable events and noisy bursts coalesce cleanly.
+- If Copilot or another bot can trigger approval-gated review events in the caller repo, add a
+  repo-owned `schedule` job that redispatches the refresh workflow through `workflow_dispatch`
+  with explicit PR number/base/head overrides.
 - Closed or merged PR refreshes can resolve from the trigger SHA; when debugging those paths,
   inspect `pull-request-context.json` before assuming GitHub returned the wrong PR.
 

--- a/skills/downstream-integration/SKILL.md
+++ b/skills/downstream-integration/SKILL.md
@@ -41,6 +41,10 @@ Use this playbook for client-repo adoption, refresh workflow fixes, and patch-co
 - If Copilot or another bot can trigger approval-gated review events in the caller repo, add a
   repo-owned `schedule` job that redispatches the refresh workflow through `workflow_dispatch`
   with explicit PR number/base/head overrides.
+- Do not make that scheduled job blindly redispatch every open PR. Prefer a guard that checks
+  whether the latest same-head refresh comment is missing or stale before redispatching.
+- Prefer keeping `cancel-in-progress` for direct event-triggered refreshes while disabling
+  cancel-on-rerun for the scheduled `workflow_dispatch` fallback path.
 - Closed or merged PR refreshes can resolve from the trigger SHA; when debugging those paths,
   inspect `pull-request-context.json` before assuming GitHub returned the wrong PR.
 

--- a/skills/pr-delivery/SKILL.md
+++ b/skills/pr-delivery/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: pr-delivery
+description: Use when finishing a feature, bugfix, or release-preparation branch in pr-agent-context. This skill covers the last-mile delivery requirement that work is only done after the branch is pushed and a non-draft GitHub PR with a detailed description, appropriate labels, and a milestone when applicable is open.
+---
+
+# PR Delivery
+
+Use this playbook when implementation work needs to be finished and published on GitHub.
+
+## When To Use
+- The user asks to open a PR.
+- The user asks to finish a feature, fix, or release-preparation change.
+- The branch already contains the implementation and the remaining work is publication and GitHub metadata.
+
+## Completion Standard
+- Do not treat the task as done while the work exists only locally.
+- Push the branch.
+- Open a non-draft PR with a detailed description.
+- Apply repository-appropriate labels.
+- Assign a milestone when one fits the work.
+- If the label or milestone is missing, create it before closing out the task.
+
+## GitHub Tooling Order
+- Use the repo-configured GitHub MCP tools first for PR creation and PR metadata updates.
+- Fall back to `gh` only for GitHub operations that the MCP does not support, such as creating a missing label or milestone.
+
+## PR Body Expectations
+- Explain the problem or pain point driving the change.
+- Summarize the implementation at a reviewer-useful level.
+- Call out workflow, docs, skill, or instruction-file updates.
+- List validation that was run and any gaps.
+
+## Final Checks
+- Confirm the PR is open and not draft.
+- Confirm labels and milestone are present.
+- Share the PR URL when reporting completion.

--- a/skills/refresh-lifecycle/SKILL.md
+++ b/skills/refresh-lifecycle/SKILL.md
@@ -25,8 +25,10 @@ Use this playbook for refresh-mode workflow design and debugging in `pr-agent-co
 - When bot-authored review events are approval-gated, prefer a repo-owned `schedule` that
   redispatches the refresh workflow through `workflow_dispatch` with explicit PR number/base/head
   overrides instead of relying only on the blocked event-triggered run.
-- Guard scheduled redispatches so they only fan out when the latest same-head refresh comment is
-  missing or stale relative to PR activity; do not blindly redispatch every open PR on every tick.
+- Guard scheduled redispatches with a bounded lookup for recent same-head refresh managed comments;
+  do not blindly redispatch every open PR on every tick.
+- Avoid staleness heuristics based on `pull.updated_at`, because publishing the managed comment can
+  perturb that timestamp and cause self-invalidating redispatch decisions.
 - Prefer leaving `cancel-in-progress` enabled for direct event-triggered refreshes while disabling
   cancel-on-rerun for scheduled `workflow_dispatch` refreshes so the fallback path does not churn
   in-flight runs.
@@ -36,8 +38,10 @@ Use this playbook for refresh-mode workflow design and debugging in `pr-agent-co
 - Check-related triggers: `status`, `check_run`, `check_suite`
 - For approval-gated bot reviews, add `workflow_dispatch` plus a `schedule` fanout job that
   dispatches same-repo open PR refreshes with explicit PR context.
-- Scheduled fanout jobs should inspect recent managed refresh comments and skip dispatch when the
-  latest same-head refresh snapshot is already current.
+- Scheduled fanout jobs should inspect a bounded window of recent comments and skip dispatch when a
+  same-head refresh managed comment already exists.
+- Add per-PR error isolation so one API failure does not block dispatch decisions for every other
+  open PR.
 - Ignore GitHub Actions-originated `check_run` events unless the task explicitly wants self-observation.
 - When refresh runs reuse prior CI coverage artifacts, point `coverage_source_workflows` at the CI producer workflow name.
 

--- a/skills/refresh-lifecycle/SKILL.md
+++ b/skills/refresh-lifecycle/SKILL.md
@@ -22,10 +22,15 @@ Use this playbook for refresh-mode workflow design and debugging in `pr-agent-co
   - `wait_for_reviews_to_settle: true` when review timing matters
 - Prefer same-repo guards before comment mutation.
 - Prefer per-PR concurrency so bursts of review/check activity collapse to the newest run.
+- When bot-authored review events are approval-gated, prefer a repo-owned `schedule` that
+  redispatches the refresh workflow through `workflow_dispatch` with explicit PR number/base/head
+  overrides instead of relying only on the blocked event-triggered run.
 
 ## Trigger Guidance
 - Core review triggers: `pull_request_review`, `pull_request_review_comment`
 - Check-related triggers: `status`, `check_run`, `check_suite`
+- For approval-gated bot reviews, add `workflow_dispatch` plus a `schedule` fanout job that
+  dispatches same-repo open PR refreshes with explicit PR context.
 - Ignore GitHub Actions-originated `check_run` events unless the task explicitly wants self-observation.
 - When refresh runs reuse prior CI coverage artifacts, point `coverage_source_workflows` at the CI producer workflow name.
 

--- a/skills/refresh-lifecycle/SKILL.md
+++ b/skills/refresh-lifecycle/SKILL.md
@@ -29,6 +29,9 @@ Use this playbook for refresh-mode workflow design and debugging in `pr-agent-co
   do not blindly redispatch every open PR on every tick.
 - Avoid staleness heuristics based on `pull.updated_at`, because publishing the managed comment can
   perturb that timestamp and cause self-invalidating redispatch decisions.
+- When refresh runs suppress all-clear comments, comment presence alone is not a sufficient skip
+  signal. Add a second dedupe guard for recent or in-flight scheduled `workflow_dispatch` runs for
+  the same PR number and head SHA.
 - Prefer leaving `cancel-in-progress` enabled for direct event-triggered refreshes while disabling
   cancel-on-rerun for scheduled `workflow_dispatch` refreshes so the fallback path does not churn
   in-flight runs.

--- a/skills/refresh-lifecycle/SKILL.md
+++ b/skills/refresh-lifecycle/SKILL.md
@@ -25,12 +25,19 @@ Use this playbook for refresh-mode workflow design and debugging in `pr-agent-co
 - When bot-authored review events are approval-gated, prefer a repo-owned `schedule` that
   redispatches the refresh workflow through `workflow_dispatch` with explicit PR number/base/head
   overrides instead of relying only on the blocked event-triggered run.
+- Guard scheduled redispatches so they only fan out when the latest same-head refresh comment is
+  missing or stale relative to PR activity; do not blindly redispatch every open PR on every tick.
+- Prefer leaving `cancel-in-progress` enabled for direct event-triggered refreshes while disabling
+  cancel-on-rerun for scheduled `workflow_dispatch` refreshes so the fallback path does not churn
+  in-flight runs.
 
 ## Trigger Guidance
 - Core review triggers: `pull_request_review`, `pull_request_review_comment`
 - Check-related triggers: `status`, `check_run`, `check_suite`
 - For approval-gated bot reviews, add `workflow_dispatch` plus a `schedule` fanout job that
   dispatches same-repo open PR refreshes with explicit PR context.
+- Scheduled fanout jobs should inspect recent managed refresh comments and skip dispatch when the
+  latest same-head refresh snapshot is already current.
 - Ignore GitHub Actions-originated `check_run` events unless the task explicitly wants self-observation.
 - When refresh runs reuse prior CI coverage artifacts, point `coverage_source_workflows` at the CI producer workflow name.
 

--- a/src/pr_agent_context/config.py
+++ b/src/pr_agent_context/config.py
@@ -589,6 +589,20 @@ def _extract_repository(env: Mapping[str, str]) -> tuple[str, str]:
     return owner, repo
 
 
+def _optional_override(value: str | None) -> str | None:
+    if value is None:
+        return None
+    stripped = value.strip()
+    return stripped or None
+
+
+def _optional_int_override(value: str | None) -> int | None:
+    stripped = _optional_override(value)
+    if stripped is None:
+        return None
+    return int(stripped)
+
+
 def load_pull_request_context_from_env(
     env: Mapping[str, str],
 ) -> tuple[str, str, PullRequestRef]:
@@ -616,7 +630,21 @@ def load_trigger_context_from_env(env: Mapping[str, str]) -> TriggerContext:
     ).strip()
     action = (env.get("PR_AGENT_CONTEXT_TRIGGER_EVENT_ACTION") or "").strip() or None
     source = _build_trigger_source(event_name, action)
-    return _extract_trigger_context(event_name, action, source, event)
+    trigger = _extract_trigger_context(event_name, action, source, event)
+
+    overrides: dict[str, object] = {}
+    if pull_request_number := _optional_int_override(
+        env.get("PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER")
+    ):
+        overrides["pull_request_number"] = pull_request_number
+    if base_sha := _optional_override(env.get("PR_AGENT_CONTEXT_BASE_SHA")):
+        overrides["base_sha"] = base_sha
+    if head_sha := _optional_override(env.get("PR_AGENT_CONTEXT_HEAD_SHA")):
+        overrides["head_sha"] = head_sha
+
+    if not overrides:
+        return trigger
+    return trigger.model_copy(update=overrides)
 
 
 def _extract_trigger_context(

--- a/src/pr_agent_context/config.py
+++ b/src/pr_agent_context/config.py
@@ -606,6 +606,31 @@ def _optional_int_override(value: str | None, *, field_name: str) -> int | None:
         raise ValueError(f"{field_name} must be an integer when provided.") from exc
 
 
+def _load_pull_request_overrides(env: Mapping[str, str]) -> dict[str, object]:
+    pull_request_number = _optional_int_override(
+        env.get("PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER"),
+        field_name="PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER",
+    )
+    base_sha = _optional_override(env.get("PR_AGENT_CONTEXT_BASE_SHA"))
+    head_sha = _optional_override(env.get("PR_AGENT_CONTEXT_HEAD_SHA"))
+
+    override_values = {
+        "pull_request_number": pull_request_number,
+        "base_sha": base_sha,
+        "head_sha": head_sha,
+    }
+    populated_override_count = sum(value is not None for value in override_values.values())
+    if populated_override_count == 0:
+        return {}
+    if populated_override_count != len(override_values):
+        raise ValueError(
+            "PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER, PR_AGENT_CONTEXT_BASE_SHA, and "
+            "PR_AGENT_CONTEXT_HEAD_SHA must all be provided together when using pull request "
+            "context overrides."
+        )
+    return override_values
+
+
 def load_pull_request_context_from_env(
     env: Mapping[str, str],
 ) -> tuple[str, str, PullRequestRef]:
@@ -634,18 +659,7 @@ def load_trigger_context_from_env(env: Mapping[str, str]) -> TriggerContext:
     action = (env.get("PR_AGENT_CONTEXT_TRIGGER_EVENT_ACTION") or "").strip() or None
     source = _build_trigger_source(event_name, action)
     trigger = _extract_trigger_context(event_name, action, source, event)
-
-    overrides: dict[str, object] = {}
-    pull_request_number = _optional_int_override(
-        env.get("PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER"),
-        field_name="PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER",
-    )
-    if pull_request_number is not None:
-        overrides["pull_request_number"] = pull_request_number
-    if base_sha := _optional_override(env.get("PR_AGENT_CONTEXT_BASE_SHA")):
-        overrides["base_sha"] = base_sha
-    if head_sha := _optional_override(env.get("PR_AGENT_CONTEXT_HEAD_SHA")):
-        overrides["head_sha"] = head_sha
+    overrides = _load_pull_request_overrides(env)
 
     if not overrides:
         return trigger

--- a/src/pr_agent_context/config.py
+++ b/src/pr_agent_context/config.py
@@ -596,11 +596,14 @@ def _optional_override(value: str | None) -> str | None:
     return stripped or None
 
 
-def _optional_int_override(value: str | None) -> int | None:
+def _optional_int_override(value: str | None, *, field_name: str) -> int | None:
     stripped = _optional_override(value)
     if stripped is None:
         return None
-    return int(stripped)
+    try:
+        return int(stripped)
+    except ValueError as exc:
+        raise ValueError(f"{field_name} must be an integer when provided.") from exc
 
 
 def load_pull_request_context_from_env(
@@ -633,9 +636,11 @@ def load_trigger_context_from_env(env: Mapping[str, str]) -> TriggerContext:
     trigger = _extract_trigger_context(event_name, action, source, event)
 
     overrides: dict[str, object] = {}
-    if pull_request_number := _optional_int_override(
-        env.get("PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER")
-    ):
+    pull_request_number = _optional_int_override(
+        env.get("PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER"),
+        field_name="PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER",
+    )
+    if pull_request_number is not None:
         overrides["pull_request_number"] = pull_request_number
     if base_sha := _optional_override(env.get("PR_AGENT_CONTEXT_BASE_SHA")):
         overrides["base_sha"] = base_sha

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1006,9 +1006,7 @@ def test_optional_int_override_parses_trimmed_integer_values():
 
 
 def test_optional_int_override_raises_clear_error_for_invalid_values():
-    with pytest.raises(
-        ValueError, match="PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER must be an integer"
-    ):
+    with pytest.raises(ValueError, match="PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER must be an integer"):
         _optional_int_override("nope", field_name="PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER")
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1134,6 +1134,30 @@ def test_load_pull_request_context_from_env_accepts_explicit_overrides(tmp_path)
     )
 
 
+def test_load_pull_request_context_from_env_rejects_partial_overrides_before_generic_failure(
+    tmp_path,
+):
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps({}), encoding="utf-8")
+
+    with pytest.raises(
+        ValueError,
+        match=(
+            "PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER, PR_AGENT_CONTEXT_BASE_SHA, and "
+            "PR_AGENT_CONTEXT_HEAD_SHA must all be provided together"
+        ),
+    ):
+        load_pull_request_context_from_env(
+            {
+                "GITHUB_REPOSITORY": "shaypal5/example",
+                "GITHUB_EVENT_PATH": str(event_path),
+                "GITHUB_EVENT_NAME": "workflow_dispatch",
+                "PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER": "17",
+                "PR_AGENT_CONTEXT_BASE_SHA": "abc123",
+            }
+        )
+
+
 def test_load_pull_request_context_from_env_uses_event_payload_when_overrides_absent(tmp_path):
     event_path = tmp_path / "event.json"
     event_path.write_text(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,8 @@ from pr_agent_context.config import (
     _extract_pull_request_shas,
     _extract_shas_from_pull_request_mapping,
     _extract_trigger_context,
+    _optional_int_override,
+    _optional_override,
     _parse_bool,
     _parse_coverage_selection_strategy,
     _parse_fork_behavior,
@@ -982,6 +984,26 @@ def test_extract_trigger_context_handles_sparse_refresh_payloads():
     assert pull_request.is_fork is None
 
 
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, None),
+        ("", None),
+        ("   ", None),
+        ("abc123", "abc123"),
+        ("  abc123  ", "abc123"),
+    ],
+)
+def test_optional_override_normalizes_blank_and_whitespace_values(value, expected):
+    assert _optional_override(value) == expected
+
+
+def test_optional_int_override_parses_trimmed_integer_values():
+    assert _optional_int_override(None) is None
+    assert _optional_int_override("   ") is None
+    assert _optional_int_override(" 17 ") == 17
+
+
 def test_load_trigger_context_from_env_applies_explicit_pull_request_overrides(tmp_path):
     event_path = tmp_path / "event.json"
     event_path.write_text(json.dumps({}), encoding="utf-8")
@@ -1003,6 +1025,36 @@ def test_load_trigger_context_from_env_applies_explicit_pull_request_overrides(t
     assert trigger.head_sha == "def456"
 
 
+def test_load_trigger_context_from_env_preserves_extracted_context_without_overrides(tmp_path):
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        json.dumps(
+            {
+                "check_run": {
+                    "head_sha": "deadbeef",
+                    "pull_requests": [{"number": 17}],
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    trigger = load_trigger_context_from_env(
+        {
+            "GITHUB_EVENT_PATH": str(event_path),
+            "GITHUB_EVENT_NAME": "check_run",
+            "PR_AGENT_CONTEXT_TRIGGER_EVENT_ACTION": "completed",
+        }
+    )
+
+    assert trigger.event_name == "check_run"
+    assert trigger.action == "completed"
+    assert trigger.source == "check_run:completed"
+    assert trigger.pull_request_number == 17
+    assert trigger.base_sha is None
+    assert trigger.head_sha == "deadbeef"
+
+
 def test_load_pull_request_context_from_env_accepts_explicit_overrides(tmp_path):
     event_path = tmp_path / "event.json"
     event_path.write_text(json.dumps({}), encoding="utf-8")
@@ -1015,6 +1067,40 @@ def test_load_pull_request_context_from_env_accepts_explicit_overrides(tmp_path)
             "PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER": "17",
             "PR_AGENT_CONTEXT_BASE_SHA": "abc123",
             "PR_AGENT_CONTEXT_HEAD_SHA": "def456",
+        }
+    )
+
+    assert owner == "shaypal5"
+    assert repo == "example"
+    assert pull_request == PullRequestRef(
+        owner="shaypal5",
+        repo="example",
+        number=17,
+        base_sha="abc123",
+        head_sha="def456",
+    )
+
+
+def test_load_pull_request_context_from_env_uses_event_payload_when_overrides_absent(tmp_path):
+    event_path = tmp_path / "event.json"
+    event_path.write_text(
+        json.dumps(
+            {
+                "pull_request": {
+                    "number": 17,
+                    "base": {"sha": "abc123"},
+                    "head": {"sha": "def456"},
+                }
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    owner, repo, pull_request = load_pull_request_context_from_env(
+        {
+            "GITHUB_REPOSITORY": "shaypal5/example",
+            "GITHUB_EVENT_PATH": str(event_path),
+            "GITHUB_EVENT_NAME": "pull_request",
         }
     )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -982,6 +982,53 @@ def test_extract_trigger_context_handles_sparse_refresh_payloads():
     assert pull_request.is_fork is None
 
 
+def test_load_trigger_context_from_env_applies_explicit_pull_request_overrides(tmp_path):
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps({}), encoding="utf-8")
+
+    trigger = load_trigger_context_from_env(
+        {
+            "GITHUB_EVENT_PATH": str(event_path),
+            "GITHUB_EVENT_NAME": "workflow_dispatch",
+            "PR_AGENT_CONTEXT_TRIGGER_EVENT_NAME": "schedule",
+            "PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER": "17",
+            "PR_AGENT_CONTEXT_BASE_SHA": "abc123",
+            "PR_AGENT_CONTEXT_HEAD_SHA": "def456",
+        }
+    )
+
+    assert trigger.event_name == "schedule"
+    assert trigger.pull_request_number == 17
+    assert trigger.base_sha == "abc123"
+    assert trigger.head_sha == "def456"
+
+
+def test_load_pull_request_context_from_env_accepts_explicit_overrides(tmp_path):
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps({}), encoding="utf-8")
+
+    owner, repo, pull_request = load_pull_request_context_from_env(
+        {
+            "GITHUB_REPOSITORY": "shaypal5/example",
+            "GITHUB_EVENT_PATH": str(event_path),
+            "GITHUB_EVENT_NAME": "workflow_dispatch",
+            "PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER": "17",
+            "PR_AGENT_CONTEXT_BASE_SHA": "abc123",
+            "PR_AGENT_CONTEXT_HEAD_SHA": "def456",
+        }
+    )
+
+    assert owner == "shaypal5"
+    assert repo == "example"
+    assert pull_request == PullRequestRef(
+        owner="shaypal5",
+        repo="example",
+        number=17,
+        base_sha="abc123",
+        head_sha="def456",
+    )
+
+
 def test_resolve_execution_mode_accepts_explicit_values():
     assert _resolve_execution_mode("ci", "status") == "ci"
     assert _resolve_execution_mode("refresh", "pull_request") == "refresh"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -999,9 +999,17 @@ def test_optional_override_normalizes_blank_and_whitespace_values(value, expecte
 
 
 def test_optional_int_override_parses_trimmed_integer_values():
-    assert _optional_int_override(None) is None
-    assert _optional_int_override("   ") is None
-    assert _optional_int_override(" 17 ") == 17
+    assert _optional_int_override(None, field_name="PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER") is None
+    assert _optional_int_override("   ", field_name="PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER") is None
+    assert _optional_int_override(" 17 ", field_name="PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER") == 17
+    assert _optional_int_override("0", field_name="PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER") == 0
+
+
+def test_optional_int_override_raises_clear_error_for_invalid_values():
+    with pytest.raises(
+        ValueError, match="PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER must be an integer"
+    ):
+        _optional_int_override("nope", field_name="PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER")
 
 
 def test_load_trigger_context_from_env_applies_explicit_pull_request_overrides(tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -15,6 +15,7 @@ from pr_agent_context.config import (
     _extract_pull_request_shas,
     _extract_shas_from_pull_request_mapping,
     _extract_trigger_context,
+    _load_pull_request_overrides,
     _optional_int_override,
     _optional_override,
     _parse_bool,
@@ -1008,6 +1009,52 @@ def test_optional_int_override_parses_trimmed_integer_values():
 def test_optional_int_override_raises_clear_error_for_invalid_values():
     with pytest.raises(ValueError, match="PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER must be an integer"):
         _optional_int_override("nope", field_name="PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER")
+
+
+def test_load_pull_request_overrides_returns_empty_when_all_are_absent():
+    assert _load_pull_request_overrides({}) == {}
+
+
+def test_load_pull_request_overrides_returns_full_override_set():
+    assert _load_pull_request_overrides(
+        {
+            "PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER": "17",
+            "PR_AGENT_CONTEXT_BASE_SHA": "abc123",
+            "PR_AGENT_CONTEXT_HEAD_SHA": "def456",
+        }
+    ) == {
+        "pull_request_number": 17,
+        "base_sha": "abc123",
+        "head_sha": "def456",
+    }
+
+
+@pytest.mark.parametrize(
+    "env",
+    [
+        {
+            "PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER": "17",
+            "PR_AGENT_CONTEXT_BASE_SHA": "abc123",
+        },
+        {
+            "PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER": "17",
+            "PR_AGENT_CONTEXT_HEAD_SHA": "def456",
+        },
+        {
+            "PR_AGENT_CONTEXT_BASE_SHA": "abc123",
+            "PR_AGENT_CONTEXT_HEAD_SHA": "def456",
+        },
+    ],
+)
+def test_load_pull_request_overrides_rejects_partial_override_sets(env):
+    with pytest.raises(
+        ValueError,
+        match=(
+            "PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER, PR_AGENT_CONTEXT_BASE_SHA, and "
+            "PR_AGENT_CONTEXT_HEAD_SHA must all be provided together"
+        ),
+    ):
+        _load_pull_request_overrides(env)
 
 
 def test_load_trigger_context_from_env_applies_explicit_pull_request_overrides(tmp_path):

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1015,6 +1015,20 @@ def test_load_pull_request_overrides_returns_empty_when_all_are_absent():
     assert _load_pull_request_overrides({}) == {}
 
 
+def test_load_pull_request_overrides_normalizes_trimmed_values():
+    assert _load_pull_request_overrides(
+        {
+            "PR_AGENT_CONTEXT_PULL_REQUEST_NUMBER": " 17 ",
+            "PR_AGENT_CONTEXT_BASE_SHA": " abc123 ",
+            "PR_AGENT_CONTEXT_HEAD_SHA": " def456 ",
+        }
+    ) == {
+        "pull_request_number": 17,
+        "base_sha": "abc123",
+        "head_sha": "def456",
+    }
+
+
 def test_load_pull_request_overrides_returns_full_override_set():
     assert _load_pull_request_overrides(
         {
@@ -1106,6 +1120,24 @@ def test_load_trigger_context_from_env_preserves_extracted_context_without_overr
     assert trigger.pull_request_number == 17
     assert trigger.base_sha is None
     assert trigger.head_sha == "deadbeef"
+
+
+def test_load_trigger_context_from_env_falls_back_to_unknown_event_name_without_overrides(tmp_path):
+    event_path = tmp_path / "event.json"
+    event_path.write_text(json.dumps({}), encoding="utf-8")
+
+    trigger = load_trigger_context_from_env(
+        {
+            "GITHUB_EVENT_PATH": str(event_path),
+        }
+    )
+
+    assert trigger.event_name == "unknown"
+    assert trigger.action is None
+    assert trigger.source == "unknown"
+    assert trigger.pull_request_number is None
+    assert trigger.base_sha is None
+    assert trigger.head_sha is None
 
 
 def test_load_pull_request_context_from_env_accepts_explicit_overrides(tmp_path):


### PR DESCRIPTION
## Summary

This change removes the manual refresh bottleneck that happens when a Copilot- or bot-authored review event leaves the refresh workflow waiting for maintainer approval.

The branch now adds a repo-owned fallback path so refresh still happens even when the original event-triggered run stalls, and it also codifies a stronger delivery rule for agents working in this repository: feature work is not done until a real GitHub PR is open with the right metadata.

## Problem

The existing refresh workflow depends on event-triggered runs from review activity and later check activity. In practice, bot-authored review events can produce refresh runs that sit in an approval-gated state for a long time. That leaves the PR without an updated handoff comment unless someone notices the blocked run, manually approves it, and waits for the workflow to finish.

That manual loop is exactly the friction this change is intended to remove.

## What Changed

### Refresh workflow hardening

- Added `workflow_dispatch` inputs to the refresh workflow so it can refresh a specific PR explicitly.
- Added a repo-owned `schedule` job that enumerates open same-repo PRs and redispatches refresh runs with explicit PR number/base/head context.
- Updated the refresh workflow guards and concurrency keys to support the dispatched path cleanly.
- Documented the scheduled-dispatch pattern in the README and the example refresh workflow.

### Reusable workflow support

- Added explicit trigger and PR-context override inputs to the reusable workflow.
- Wired those inputs into the runtime environment.
- Updated config loading so `pr-agent-context` can resolve PR context from those explicit overrides for dispatch- or schedule-driven refreshes.
- Added config tests covering the new override behavior.

### Agent delivery policy

- Updated `AGENTS.md` and `.github/copilot-instructions.md` to make the delivery bar explicit: feature or PR work is only complete once a non-draft PR with a detailed description is open on GitHub and has the right metadata.
- Added `memory/MEMORY.md` to encode that rule as repo-local agent memory.
- Added a new repo-local skill at `skills/pr-delivery/SKILL.md` for the final PR publication step.

## Validation

- `pytest tests/test_config.py tests/test_cli.py`
- Parsed workflow/example YAML successfully for:
  - `.github/workflows/pr-agent-context.yml`
  - `.github/workflows/pr-agent-context-refresh.yml`
  - `examples/pr-agent-context-refresh.yml`

## Notes

- Existing repo labels were reused where they already fit.
- A new milestone was created for this class of work so the PR can land with milestone metadata instead of leaving that step undone.