### PR TITLE
Fix self-refresh startup failure on review-triggered runs

### DIFF
--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -231,9 +231,9 @@ jobs:
          github.event.inputs.pull_request_base_sha != '' &&
          github.event.inputs.pull_request_head_sha != '')
       )
-    uses: shaypal5/pr-agent-context/.github/workflows/pr-agent-context.yml@v4
+    uses: ./.github/workflows/pr-agent-context.yml
     with:
-      tool_ref: v4
+      tool_ref: ${{ github.event.pull_request.head.sha || github.sha }}
       execution_mode: refresh
       trigger_event_name_override: ${{ github.event.inputs.trigger_event_name || '' }}
       trigger_event_action_override: ${{ github.event.inputs.trigger_event_action || '' }}

--- a/README.md
+++ b/README.md
@@ -553,6 +553,12 @@ Additional copy-pasteable examples live in [`examples/`](examples/):
 Refresh mode is best-effort on forks. When write access, external checks, or artifact access are
 restricted, the tool records those degradations in debug artifacts instead of failing wholesale.
 
+This repository's own
+[`pr-agent-context-refresh.yml`](.github/workflows/pr-agent-context-refresh.yml) intentionally
+calls the local reusable workflow path and uses the PR head SHA as `tool_ref` when available. That
+keeps self-dogfooding branches branch-coupled so new caller inputs cannot drift ahead of the local
+reusable workflow contract during review-triggered refreshes.
+
 If Copilot or another bot can leave review-triggered refresh runs waiting for maintainer approval,
 the scheduled dispatcher pattern above avoids depending on that blocked run. The schedule wakes up
 as the repository itself, enumerates open same-repo PRs, and uses a composite dedupe guard before

--- a/skills/refresh-lifecycle/SKILL.md
+++ b/skills/refresh-lifecycle/SKILL.md
@@ -21,6 +21,9 @@ Use this playbook for refresh-mode workflow design and debugging in `pr-agent-co
   - `enable_cross_run_coverage_lookup: true`
   - `wait_for_reviews_to_settle: true` when review timing matters
 - Prefer same-repo guards before comment mutation.
+- In this repository's own self-refresh workflow, prefer a branch-coupled local reusable workflow
+  call plus PR-head `tool_ref` over calling a released `@v4` reusable workflow. That keeps the
+  self-dogfooding caller/callee contract aligned while unreleased inputs are still evolving.
 - Prefer per-PR concurrency so bursts of review/check activity collapse to the newest run.
 - When bot-authored review events are approval-gated, prefer a repo-owned `schedule` that
   redispatches the refresh workflow through `workflow_dispatch` with explicit PR number/base/head

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _load_workflow(relative_path: str) -> dict[str, object]:
+    workflow = yaml.load(
+        (REPO_ROOT / relative_path).read_text(encoding="utf-8"),
+        Loader=yaml.BaseLoader,
+    )
+    assert isinstance(workflow, dict)
+    return workflow
+
+
+def test_self_refresh_uses_local_reusable_workflow_contract():
+    refresh_workflow = _load_workflow(".github/workflows/pr-agent-context-refresh.yml")
+    reusable_workflow = _load_workflow(".github/workflows/pr-agent-context.yml")
+
+    refresh_job = refresh_workflow["jobs"]["pr-agent-context-refresh"]
+    reusable_inputs = reusable_workflow["on"]["workflow_call"]["inputs"]
+
+    assert refresh_job["uses"] == "./.github/workflows/pr-agent-context.yml"
+    assert refresh_job["with"]["tool_ref"] == "${{ github.event.pull_request.head.sha || github.sha }}"
+    assert set(refresh_job["with"]).issubset(set(reusable_inputs))

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import yaml
 
-
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
@@ -25,5 +24,7 @@ def test_self_refresh_uses_local_reusable_workflow_contract():
     reusable_inputs = reusable_workflow["on"]["workflow_call"]["inputs"]
 
     assert refresh_job["uses"] == "./.github/workflows/pr-agent-context.yml"
-    assert refresh_job["with"]["tool_ref"] == "${{ github.event.pull_request.head.sha || github.sha }}"
+    assert (
+        refresh_job["with"]["tool_ref"] == "${{ github.event.pull_request.head.sha || github.sha }}"
+    )
     assert set(refresh_job["with"]).issubset(set(reusable_inputs))


### PR DESCRIPTION
## Summary
- switch the repo's self-refresh workflow to the branch-local reusable workflow instead of calling `pr-agent-context.yml@v4`
- use the PR head SHA as `tool_ref` when available so self-dogfooding refresh runs execute the matching branch code
- add a workflow contract test and document the self-dogfooding rule in the README and refresh lifecycle skill

## Problem
Issue #89 tracks review-triggered self-refresh runs that were ending in `startup_failure` before any jobs were created. The branch caller workflow had evolved to pass explicit PR override inputs that the released `@v4` reusable workflow interface did not expose, so GitHub rejected the run during workflow startup.

## Implementation
The self-refresh job in `.github/workflows/pr-agent-context-refresh.yml` now uses `./.github/workflows/pr-agent-context.yml` so the caller and callee contracts move together on the branch. It also sets `tool_ref` to `${{ github.event.pull_request.head.sha || github.sha }}` so same-repo PR refreshes execute the matching branch version of the tool when a PR head SHA exists.

I also added `tests/test_workflow_contracts.py`, which parses the workflow YAML and asserts that the self-refresh job uses the local reusable workflow and that every `with:` input is declared by the reusable workflow's `workflow_call` interface. That gives CI a direct guard against the caller/callee contract drift that caused the zero-job startup failures.

## Validation
- `pytest -q tests/test_workflow_contracts.py`
- `pytest -q tests/test_config.py -k 'override or workflow_dispatch'`
- `pytest -q` reached 72% with no failures before the run hung in the tail; the targeted workflow/config coverage above completed successfully

Fixes #89
