### PR TITLE
Fix self-repo split-checkout patch coverage

### DIFF
--- a/src/pr_agent_context/coverage/combine.py
+++ b/src/pr_agent_context/coverage/combine.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import os
 import tempfile
 from contextlib import contextmanager
-from pathlib import Path
+from pathlib import Path, PurePosixPath
 
 from coverage import Coverage, CoverageData
 from coverage.exceptions import DataError
@@ -44,6 +44,7 @@ def build_combined_coverage(*, workspace: Path, coverage_files: list[Path]) -> C
                 data_paths=[str(path) for path in normalized_coverage_files],
                 strict=False,
             )
+            _add_workspace_relative_filename_aliases(coverage, workspace)
             coverage.save()
             coverage.load()
     return coverage
@@ -95,3 +96,62 @@ def _is_valid_coverage_file(path: Path) -> bool:
     except (DataError, OSError):
         return False
     return True
+
+
+def _add_workspace_relative_filename_aliases(coverage: Coverage, workspace: Path) -> None:
+    workspace_root = workspace.resolve()
+    lines_to_add: dict[str, list[int]] = {}
+    arcs_to_add: dict[str, list[tuple[int, int]]] = {}
+    tracers_to_add: dict[str, str] = {}
+    data = coverage.get_data()
+
+    for measured_path in data.measured_files():
+        aliased_path = _rebase_measured_path_to_workspace(measured_path, workspace_root)
+        if aliased_path is None or aliased_path == measured_path:
+            continue
+        if aliased_path in data.measured_files():
+            continue
+
+        if lines := data.lines(measured_path):
+            lines_to_add[aliased_path] = list(lines)
+        if arcs := data.arcs(measured_path):
+            arcs_to_add[aliased_path] = list(arcs)
+        if tracer := data.file_tracer(measured_path):
+            tracers_to_add[aliased_path] = tracer
+
+    if lines_to_add:
+        data.add_lines(lines_to_add)
+    if arcs_to_add:
+        data.add_arcs(arcs_to_add)
+    if tracers_to_add:
+        data.add_file_tracers(tracers_to_add)
+
+
+def _rebase_measured_path_to_workspace(path: str, workspace_root: Path) -> str | None:
+    measured_path = Path(path)
+    try:
+        resolved_measured_path = measured_path.resolve()
+    except OSError:
+        return None
+
+    try:
+        relative_path = resolved_measured_path.relative_to(workspace_root).as_posix()
+    except ValueError:
+        pass
+    else:
+        return str((workspace_root / relative_path).resolve())
+
+    suffix = _find_workspace_relative_suffix(measured_path, workspace_root)
+    if suffix is None:
+        return None
+    return str((workspace_root / suffix).resolve())
+
+
+def _find_workspace_relative_suffix(measured_path: Path, workspace_root: Path) -> str | None:
+    path_parts = measured_path.parts
+    for start_index in range(1, len(path_parts)):
+        suffix = PurePosixPath(*path_parts[start_index:]).as_posix()
+        candidate = workspace_root / suffix
+        if candidate.exists():
+            return suffix
+    return None

--- a/tests/test_patch_coverage.py
+++ b/tests/test_patch_coverage.py
@@ -1261,14 +1261,45 @@ def test_compute_patch_coverage_rebases_absolute_measured_paths_from_split_check
     )
 
     assert summary.is_na is False
-    assert summary.actual_percent == 0
+    assert summary.actual_percent == 75
     assert summary.total_changed_executable_lines == 4
     assert [file_gap.path for file_gap in summary.files] == ["src/pkg/module.py"]
-    assert summary.files[0].covered_changed_executable_lines == []
-    assert summary.files[0].uncovered_changed_executable_lines == [1, 2, 3, 4]
+    assert summary.files[0].covered_changed_executable_lines == [1, 2, 3]
+    assert summary.files[0].uncovered_changed_executable_lines == [4]
     assert summary.files[0].has_measured_data is True
     assert scope_debug["scope_strategy"] == "measured_root_inference"
     assert scope_debug["inferred_source_roots"] == ["src/pkg"]
+
+
+def test_build_combined_coverage_adds_workspace_alias_for_absolute_split_checkout_paths(tmp_path):
+    job_workspace = tmp_path / "job-workspace"
+    repo = job_workspace / "caller-repo"
+    repo.mkdir(parents=True)
+    source_path = repo / "src" / "pkg" / "module.py"
+    _write_file(
+        source_path,
+        "def parse(flag):\n    if flag:\n        return 1\n    return 2\n",
+    )
+
+    coverage_dir = job_workspace / "coverage-artifacts"
+    coverage_dir.mkdir(parents=True)
+    coverage_file = coverage_dir / ".coverage.py312"
+    _build_coverage_data_with_recorded_filenames(
+        coverage_file,
+        [
+            (
+                "/home/runner/work/pr-agent-context/pr-agent-context/src/pkg/module.py",
+                source_path,
+                "parse(True)",
+            )
+        ],
+    )
+
+    combined = build_combined_coverage(workspace=repo, coverage_files=[coverage_file])
+    measured_files = set(combined.get_data().measured_files())
+
+    assert str(source_path.resolve()) in measured_files
+    assert combined.analysis2(str(source_path))[3] == [4]
 
 
 def test_find_coverage_config_file_prefers_existing_project_config(tmp_path):


### PR DESCRIPTION
## Summary
- fix combined coverage handling for self-repo split-checkout absolute measured filenames by adding workspace-local filename aliases after combine
- make the self-repo split-checkout patch coverage test assert the real covered result instead of the previous broken `0%` fallback
- add a combine-level regression test that proves `coverage.analysis2()` can resolve the rebased caller checkout path

## Problem
Issue #88 tracks a release-line correctness bug where this repo's self-consumer CI could still report `Patch test coverage is 0%` for changed Python lines when the measured filenames came from the split-checkout self-repo path shape under `/home/runner/work/pr-agent-context/pr-agent-context/...`.

The normalization code could already map that path shape back to `src/...`, but the combined coverage data still only stored the original absolute filename. When `compute_patch_coverage()` later asked coverage.py to analyze the caller checkout file, coverage.py treated the file as entirely missing coverage and returned the broken `0%` result.

## Implementation
- preserve the existing path normalization logic in patch coverage scope detection
- extend `build_combined_coverage()` to add workspace-local filename aliases for absolute measured paths whose deepest existing suffix matches a file inside the caller workspace
- copy recorded line, arc, and tracer data onto the aliased filename so later `coverage.analysis2()` calls resolve against the caller checkout path
- update the self-repo split-checkout regression to expect `75%` patch coverage with only the truly uncovered line reported

## Validation
- `pytest tests/test_patch_coverage.py`

## Notes
- Fixes #88.
