### PR TITLE
Optimize failed-step log extraction for large Actions job logs

### DIFF
--- a/src/pr_agent_context/github/workflow_jobs.py
+++ b/src/pr_agent_context/github/workflow_jobs.py
@@ -205,15 +205,14 @@ def _scan_target_step_blocks(
 
     def flush_current_step() -> None:
         nonlocal current_step, current_normalized_step, current_lines, capture_current_step
-        if current_step is None or current_normalized_step is None:
-            return
-        grouped_step_counts[current_normalized_step] = (
-            grouped_step_counts.get(current_normalized_step, 0) + 1
-        )
-        if capture_current_step:
-            grouped_step_matches.setdefault(current_normalized_step, []).append(
-                (current_step, current_lines)
+        if current_step is not None and current_normalized_step is not None:
+            grouped_step_counts[current_normalized_step] = (
+                grouped_step_counts.get(current_normalized_step, 0) + 1
             )
+            if capture_current_step:
+                grouped_step_matches.setdefault(current_normalized_step, []).append(
+                    (current_step, current_lines)
+                )
         current_step = None
         current_normalized_step = None
         current_lines = []

--- a/src/pr_agent_context/github/workflow_jobs.py
+++ b/src/pr_agent_context/github/workflow_jobs.py
@@ -172,18 +172,17 @@ def extract_failed_step_output_lines(
     if max_lines <= 0 or not failed_steps or not lines:
         return None, []
 
-    grouped_steps = _group_step_blocks(lines)
-    if not grouped_steps:
+    normalized_failed_steps = [_normalize_step_name(step_name) for step_name in failed_steps]
+    target_names = {step_name for step_name in normalized_failed_steps if step_name}
+    if not target_names:
         return None, []
 
-    normalized_lookup = {}
-    for step_name, step_lines in grouped_steps:
-        normalized_lookup.setdefault(_normalize_step_name(step_name), []).append(
-            (step_name, step_lines)
-        )
+    grouped_step_counts, grouped_step_matches = _scan_target_step_blocks(lines, target_names)
 
-    for failed_step in failed_steps:
-        matches = normalized_lookup.get(_normalize_step_name(failed_step), [])
+    for normalized_failed_step in normalized_failed_steps:
+        if grouped_step_counts.get(normalized_failed_step) != 1:
+            continue
+        matches = grouped_step_matches.get(normalized_failed_step, [])
         if len(matches) != 1:
             continue
         step_name, step_lines = matches[0]
@@ -191,6 +190,59 @@ def extract_failed_step_output_lines(
         return step_name, trimmed_step_lines[:max_lines]
 
     return None, []
+
+
+def _scan_target_step_blocks(
+    lines: list[str],
+    target_names: set[str],
+) -> tuple[dict[str, int], dict[str, list[tuple[str, list[str]]]]]:
+    grouped_step_counts: dict[str, int] = {}
+    grouped_step_matches: dict[str, list[tuple[str, list[str]]]] = {}
+    current_step: str | None = None
+    current_normalized_step: str | None = None
+    current_lines: list[str] = []
+    capture_current_step = False
+
+    def flush_current_step() -> None:
+        nonlocal current_step, current_normalized_step, current_lines, capture_current_step
+        if current_step is None or current_normalized_step is None:
+            return
+        grouped_step_counts[current_normalized_step] = (
+            grouped_step_counts.get(current_normalized_step, 0) + 1
+        )
+        if capture_current_step:
+            grouped_step_matches.setdefault(current_normalized_step, []).append(
+                (current_step, current_lines)
+            )
+        current_step = None
+        current_normalized_step = None
+        current_lines = []
+        capture_current_step = False
+
+    for line in lines:
+        step_name = _extract_grouped_step_name(line)
+        if step_name is not None:
+            flush_current_step()
+            normalized_step_name = _normalize_step_name(step_name)
+            current_step = step_name
+            current_normalized_step = (
+                normalized_step_name if normalized_step_name in target_names else None
+            )
+            capture_current_step = current_normalized_step is not None
+            current_lines = [line] if capture_current_step else []
+            continue
+
+        if current_step is None:
+            continue
+
+        if capture_current_step:
+            current_lines.append(line)
+
+        if line.strip() == "##[endgroup]":
+            flush_current_step()
+
+    flush_current_step()
+    return grouped_step_counts, grouped_step_matches
 
 
 def _group_step_blocks(lines: list[str]) -> list[tuple[str, list[str]]]:

--- a/tests/test_workflow_jobs.py
+++ b/tests/test_workflow_jobs.py
@@ -4,10 +4,12 @@ from io import BytesIO
 from zipfile import ZipFile
 
 from conftest import load_text_fixture
+from pr_agent_context.github import workflow_jobs as workflow_jobs_module
 from pr_agent_context.github.workflow_jobs import (
     _extract_grouped_step_name,
     _group_step_blocks,
     _normalize_step_name,
+    _scan_target_step_blocks,
     _trim_trailing_blank_lines,
     collect_failed_jobs,
     extract_failed_step_output,
@@ -260,6 +262,14 @@ def test_extract_failed_step_output_lines_scans_only_relevant_failed_steps():
     )
 
 
+def test_extract_failed_step_output_lines_returns_none_when_failed_steps_normalize_to_empty():
+    assert extract_failed_step_output_lines(
+        ["2026-03-07T10:00:00Z ##[group]Run pytest", "failed"],
+        failed_steps=["   "],
+        max_lines=10,
+    ) == (None, [])
+
+
 def test_extract_failed_step_output_lines_skips_ambiguous_first_match_for_later_unique_step():
     lines = [
         "2026-03-07T10:00:00Z ##[group]Run pytest",
@@ -314,6 +324,85 @@ def test_extract_failed_step_output_lines_handles_duplicate_and_unterminated_can
     )
 
 
+def test_extract_failed_step_output_lines_resets_state_after_irrelevant_group_end():
+    lines = [
+        "2026-03-07T10:00:00Z ##[group]Run setup",
+        "setup output",
+        "##[endgroup]",
+        "outside group",
+        "2026-03-07T10:00:01Z ##[group]Run pytest",
+        "pytest failed",
+        "##[endgroup]",
+    ]
+
+    assert extract_failed_step_output_lines(
+        lines,
+        failed_steps=["Run pytest"],
+        max_lines=10,
+    ) == (
+        "pytest",
+        [
+            "2026-03-07T10:00:01Z ##[group]Run pytest",
+            "pytest failed",
+            "##[endgroup]",
+        ],
+    )
+
+
+def test_extract_failed_step_output_lines_skips_inconsistent_single_count_match_state(monkeypatch):
+    def fake_scan_target_step_blocks(lines, target_names):  # noqa: ANN001
+        return {"pytest": 1}, {"pytest": [("pytest", ["first"]), ("pytest", ["second"])]}
+
+    monkeypatch.setattr(
+        workflow_jobs_module,
+        "_scan_target_step_blocks",
+        fake_scan_target_step_blocks,
+    )
+
+    assert extract_failed_step_output_lines(
+        ["2026-03-07T10:00:00Z ##[group]Run pytest", "pytest failed"],
+        failed_steps=["Run pytest"],
+        max_lines=10,
+    ) == (None, [])
+
+
+def test_scan_target_step_blocks_tracks_only_requested_step_names():
+    lines = [
+        "2026-03-07T10:00:00Z ##[group]Run setup",
+        "setup output",
+        "##[endgroup]",
+        "outside group",
+        "2026-03-07T10:00:01Z ##[group]Run pytest",
+        "pytest failed",
+        "##[endgroup]",
+        "2026-03-07T10:00:02Z ##[group]Run pytest",
+        "pytest failed again",
+    ]
+
+    counts, matches = _scan_target_step_blocks(lines, {"pytest"})
+
+    assert counts == {"pytest": 2}
+    assert matches == {
+        "pytest": [
+            (
+                "pytest",
+                [
+                    "2026-03-07T10:00:01Z ##[group]Run pytest",
+                    "pytest failed",
+                    "##[endgroup]",
+                ],
+            ),
+            (
+                "pytest",
+                [
+                    "2026-03-07T10:00:02Z ##[group]Run pytest",
+                    "pytest failed again",
+                ],
+            ),
+        ]
+    }
+
+
 def test_step_block_helpers_cover_grouping_and_normalization_edges():
     lines = [
         "before group",
@@ -331,6 +420,17 @@ def test_step_block_helpers_cover_grouping_and_normalization_edges():
     assert _normalize_step_name("pytest  ") == "pytest"
     assert _trim_trailing_blank_lines(["line 1", "", "  "]) == ["line 1"]
     assert _group_step_blocks([]) == []
+    assert _group_step_blocks(
+        [
+            "2026-03-07T10:00:00Z ##[group]Run mypy",
+            "line 1",
+            "2026-03-07T10:00:01Z ##[group]Run pytest",
+            "line 2",
+        ]
+    ) == [
+        ("mypy", ["2026-03-07T10:00:00Z ##[group]Run mypy", "line 1"]),
+        ("pytest", ["2026-03-07T10:00:01Z ##[group]Run pytest", "line 2"]),
+    ]
     assert _group_step_blocks(lines) == [
         ("mypy", ["2026-03-07T10:00:00Z ##[group]Run mypy", "line 1", "##[endgroup]"]),
         ("pytest", ["2026-03-07T10:00:01Z ##[group]Run pytest", "line 2"]),

--- a/tests/test_workflow_jobs.py
+++ b/tests/test_workflow_jobs.py
@@ -228,6 +228,92 @@ def test_extract_failed_step_output_lines_prefers_unique_failed_step_match_order
     ) == ("mypy", ["2026-03-07T10:00:01Z ##[group]Run mypy", "mypy failed", "##[endgroup]"])
 
 
+def test_extract_failed_step_output_lines_scans_only_relevant_failed_steps():
+    lines = [
+        "2026-03-07T10:00:00Z ##[group]Run setup",
+        "setup output",
+        "##[endgroup]",
+        "2026-03-07T10:00:01Z ##[group]Run lint",
+        "lint output",
+        "##[endgroup]",
+        "2026-03-07T10:00:02Z ##[group]Run pytest",
+        "tests/test_example.py::test_behavior FAILED",
+        "##[error]Process completed with exit code 1.",
+        "##[endgroup]",
+        "2026-03-07T10:00:03Z ##[group]Run summary",
+        "summary output",
+        "##[endgroup]",
+    ]
+
+    assert extract_failed_step_output_lines(
+        lines,
+        failed_steps=["Run pytest"],
+        max_lines=10,
+    ) == (
+        "pytest",
+        [
+            "2026-03-07T10:00:02Z ##[group]Run pytest",
+            "tests/test_example.py::test_behavior FAILED",
+            "##[error]Process completed with exit code 1.",
+            "##[endgroup]",
+        ],
+    )
+
+
+def test_extract_failed_step_output_lines_skips_ambiguous_first_match_for_later_unique_step():
+    lines = [
+        "2026-03-07T10:00:00Z ##[group]Run pytest",
+        "first pytest block",
+        "##[endgroup]",
+        "2026-03-07T10:00:01Z ##[group]Run mypy",
+        "mypy failed",
+        "##[endgroup]",
+        "2026-03-07T10:00:02Z ##[group]Run pytest",
+        "second pytest block",
+        "##[endgroup]",
+    ]
+
+    assert extract_failed_step_output_lines(
+        lines,
+        failed_steps=["Run pytest", "Run mypy"],
+        max_lines=10,
+    ) == ("mypy", ["2026-03-07T10:00:01Z ##[group]Run mypy", "mypy failed", "##[endgroup]"])
+
+
+def test_extract_failed_step_output_lines_handles_duplicate_and_unterminated_candidate_groups():
+    duplicate_lines = [
+        "2026-03-07T10:00:00Z ##[group]Run pytest",
+        "first pytest block",
+        "##[endgroup]",
+        "2026-03-07T10:00:01Z ##[group]Run pytest",
+        "second pytest block",
+        "##[endgroup]",
+    ]
+    unterminated_lines = [
+        "2026-03-07T10:00:00Z ##[group]Run pytest",
+        "tests/test_example.py::test_behavior FAILED",
+        "",
+        "   ",
+    ]
+
+    assert extract_failed_step_output_lines(
+        duplicate_lines,
+        failed_steps=["Run pytest"],
+        max_lines=10,
+    ) == (None, [])
+    assert extract_failed_step_output_lines(
+        unterminated_lines,
+        failed_steps=["Run pytest"],
+        max_lines=10,
+    ) == (
+        "pytest",
+        [
+            "2026-03-07T10:00:00Z ##[group]Run pytest",
+            "tests/test_example.py::test_behavior FAILED",
+        ],
+    )
+
+
 def test_step_block_helpers_cover_grouping_and_normalization_edges():
     lines = [
         "before group",


### PR DESCRIPTION
## Summary
- refactor failed-step output extraction to scan GitHub Actions logs once
- retain grouped step blocks only for requested failed-step candidates instead of materializing every block
- preserve duplicate-match fallback and failed-step priority semantics while reducing work on large logs

## Problem
Issue #76 identified that `extract_failed_step_output_lines()` built grouped blocks for the entire job log before matching failed steps. On large Actions logs this does extra memory and CPU work even though the caller only needs a uniquely matched failed-step block.

Closes #76.

## Implementation
- normalize the requested failed steps up front and derive a target-name set
- add a single-pass grouped-step scanner that counts matches for requested step names while storing lines only for those candidate blocks
- keep the existing grouped-step parsing, trailing-blank trimming, and fallback behavior intact
- add regression tests for relevant-only scanning, duplicate candidate groups, failed-step priority ordering, and unterminated grouped blocks

## Validation
- `pytest tests/test_workflow_jobs.py`
- `pytest tests/test_failing_checks.py`

## Notes
- no workflow, README, or skill changes were required because this is an internal performance refactor with no intended behavior change