### PR TITLE
Fix branch-mode raw coverage alias handling

### DIFF
--- a/src/pr_agent_context/coverage/combine.py
+++ b/src/pr_agent_context/coverage/combine.py
@@ -100,10 +100,11 @@ def _is_valid_coverage_file(path: Path) -> bool:
 
 def _add_workspace_relative_filename_aliases(coverage: Coverage, workspace: Path) -> None:
     workspace_root = workspace.resolve()
-    lines_to_add: dict[str, list[int]] = {}
-    arcs_to_add: dict[str, list[tuple[int, int]]] = {}
     tracers_to_add: dict[str, str] = {}
     data = coverage.get_data()
+    uses_arcs = data.has_arcs()
+    lines_to_add: dict[str, list[int]] = {}
+    arcs_to_add: dict[str, list[tuple[int, int]]] = {}
 
     for measured_path in data.measured_files():
         aliased_path = _rebase_measured_path_to_workspace(measured_path, workspace_root)
@@ -112,17 +113,19 @@ def _add_workspace_relative_filename_aliases(coverage: Coverage, workspace: Path
         if aliased_path in data.measured_files():
             continue
 
-        if lines := data.lines(measured_path):
-            lines_to_add[aliased_path] = list(lines)
-        if arcs := data.arcs(measured_path):
-            arcs_to_add[aliased_path] = list(arcs)
+        if uses_arcs:
+            if arcs := data.arcs(measured_path):
+                arcs_to_add[aliased_path] = list(arcs)
+        else:
+            if lines := data.lines(measured_path):
+                lines_to_add[aliased_path] = list(lines)
         if tracer := data.file_tracer(measured_path):
             tracers_to_add[aliased_path] = tracer
 
-    if lines_to_add:
-        data.add_lines(lines_to_add)
     if arcs_to_add:
         data.add_arcs(arcs_to_add)
+    if lines_to_add:
+        data.add_lines(lines_to_add)
     if tracers_to_add:
         data.add_file_tracers(tracers_to_add)
 

--- a/tests/test_patch_coverage.py
+++ b/tests/test_patch_coverage.py
@@ -43,7 +43,20 @@ def _write_file(path: Path, content: str) -> None:
 
 
 def _build_coverage_data(data_file: Path, scripts: list[tuple[Path, str]]) -> None:
-    coverage = Coverage(config_file=False, data_file=str(data_file))
+    _build_coverage_data_with_options(data_file, scripts, branch=False)
+
+
+def _build_branch_coverage_data(data_file: Path, scripts: list[tuple[Path, str]]) -> None:
+    _build_coverage_data_with_options(data_file, scripts, branch=True)
+
+
+def _build_coverage_data_with_options(
+    data_file: Path,
+    scripts: list[tuple[Path, str]],
+    *,
+    branch: bool,
+) -> None:
+    coverage = Coverage(config_file=False, data_file=str(data_file), branch=branch)
     coverage.start()
     for script_path, invocation in scripts:
         globals_dict = {"__name__": "__main__"}
@@ -59,8 +72,10 @@ def _build_coverage_data(data_file: Path, scripts: list[tuple[Path, str]]) -> No
 def _build_coverage_data_with_recorded_filenames(
     data_file: Path,
     scripts: list[tuple[str, Path, str]],
+    *,
+    branch: bool = False,
 ) -> None:
-    coverage = Coverage(config_file=False, data_file=str(data_file))
+    coverage = Coverage(config_file=False, data_file=str(data_file), branch=branch)
     coverage.start()
     for recorded_filename, script_path, invocation in scripts:
         globals_dict = {"__name__": "__main__"}
@@ -1293,6 +1308,38 @@ def test_build_combined_coverage_adds_workspace_alias_for_absolute_split_checkou
                 "parse(True)",
             )
         ],
+    )
+
+    combined = build_combined_coverage(workspace=repo, coverage_files=[coverage_file])
+    measured_files = set(combined.get_data().measured_files())
+
+    assert str(source_path.resolve()) in measured_files
+    assert combined.analysis2(str(source_path))[3] == [4]
+
+
+def test_build_combined_coverage_adds_workspace_alias_for_branch_mode_paths(tmp_path):
+    job_workspace = tmp_path / "job-workspace"
+    repo = job_workspace / "caller-repo"
+    repo.mkdir(parents=True)
+    source_path = repo / "src" / "pkg" / "module.py"
+    _write_file(
+        source_path,
+        "def parse(flag):\n    if flag:\n        return 1\n    return 2\n",
+    )
+
+    coverage_dir = job_workspace / "coverage-artifacts"
+    coverage_dir.mkdir(parents=True)
+    coverage_file = coverage_dir / ".coverage.py312"
+    _build_coverage_data_with_recorded_filenames(
+        coverage_file,
+        [
+            (
+                "/home/runner/work/pr-agent-context/pr-agent-context/src/pkg/module.py",
+                source_path,
+                "parse(True)",
+            )
+        ],
+        branch=True,
     )
 
     combined = build_combined_coverage(workspace=repo, coverage_files=[coverage_file])


### PR DESCRIPTION
## Summary
- fix workspace alias registration for combined raw coverage artifacts collected in branch mode
- only write alias data using the coverage database's active measurement type instead of mixing line writes into arc-mode data
- add a regression test for split-checkout path aliasing when the input `.coverage` file was recorded with branch coverage enabled

## Problem
Issue #95 reports that `pr-agent-context` crashes during raw coverage artifact processing with `coverage.exceptions.DataError: Can't add line measurements to existing branch data` when the downloaded `.coverage` files were produced with branch coverage enabled.

The failure comes from `_add_workspace_relative_filename_aliases`, which always attempted `add_lines(...)` whenever line data existed, even when the combined coverage database was in arc mode.

## Implementation
- detect the combined coverage database mode with `CoverageData.has_arcs()`
- for alias paths, add only arcs in branch/arc mode and only lines in line mode
- keep file tracer alias registration unchanged
- cover the failing branch-mode split-checkout case in `tests/test_patch_coverage.py`

## Validation
- `ruff check src/pr_agent_context/coverage/combine.py tests/test_patch_coverage.py`
- `pytest tests/test_patch_coverage.py`

Fixes #95.
