### PR TITLE
Include repository URL in prompts and fix branch coverage aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,9 @@ If `prompt_template_file` is not provided, `pr-agent-context` uses the built-in 
 template. If it is provided, the file is loaded from the caller repository workspace and
 rendered deterministically with a small placeholder renderer.
 
+When repository context is available, the built-in opening instructions include the caller
+repository URL in the first sentence, for example `in repository https://github.com/owner/repo`.
+
 Supported placeholders:
 
 - `{{ pr_number }}`

--- a/src/pr_agent_context/config.py
+++ b/src/pr_agent_context/config.py
@@ -137,7 +137,7 @@ def _extract_codecov_patch_target(data: object) -> float | None:
 def _parse_percent_like_value(value: object) -> float | None:
     if isinstance(value, bool) or value is None:
         return None
-    if isinstance(value, (int, float)):
+    if isinstance(value, int | float):
         numeric = float(value)
         if 0 <= numeric <= 1:
             return numeric * 100
@@ -229,6 +229,7 @@ class RunConfig(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
 
     github_api_url: str = "https://api.github.com"
+    github_server_url: str = "https://github.com"
     github_token: str
     tool_ref: str = DEFAULT_TOOL_REF
     repository_owner: str = ""
@@ -306,6 +307,13 @@ class RunConfig(BaseModel):
             return f"{self.pull_request.owner}/{self.pull_request.repo}"
         return ""
 
+    @property
+    def repository_url(self) -> str:
+        repository = self.repository
+        if not repository:
+            return ""
+        return f"{self.github_server_url.rstrip('/')}/{repository}"
+
     @model_validator(mode="after")
     def _validate_patch_coverage_source_config(self) -> RunConfig:
         if (
@@ -352,6 +360,7 @@ class RunConfig(BaseModel):
 
         return cls(
             github_api_url=env_map.get("GITHUB_API_URL", "https://api.github.com"),
+            github_server_url=env_map.get("GITHUB_SERVER_URL", "https://github.com"),
             github_token=env_map["GITHUB_TOKEN"],
             tool_ref=env_map.get("PR_AGENT_CONTEXT_TOOL_REF", DEFAULT_TOOL_REF).strip()
             or DEFAULT_TOOL_REF,

--- a/src/pr_agent_context/constants.py
+++ b/src/pr_agent_context/constants.py
@@ -5,7 +5,7 @@ MANAGED_COMMENT_SCHEMA_VERSION = "v5"
 
 DEFAULT_ALL_CLEAR_PROMPT = (
     "No unresolved review comments, failing checks, or actionable patch "
-    "coverage gaps were found on PR #{pr_number}. Treat this PR as all clear "
+    "coverage gaps were found on {pr_reference}. Treat this PR as all clear "
     "unless new signals appear."
 )
 

--- a/src/pr_agent_context/coverage/combine.py
+++ b/src/pr_agent_context/coverage/combine.py
@@ -112,10 +112,11 @@ def _add_workspace_relative_filename_aliases(coverage: Coverage, workspace: Path
         if aliased_path in data.measured_files():
             continue
 
-        if lines := data.lines(measured_path):
+        if data.has_arcs():
+            if arcs := data.arcs(measured_path):
+                arcs_to_add[aliased_path] = list(arcs)
+        elif lines := data.lines(measured_path):
             lines_to_add[aliased_path] = list(lines)
-        if arcs := data.arcs(measured_path):
-            arcs_to_add[aliased_path] = list(arcs)
         if tracer := data.file_tracer(measured_path):
             tracers_to_add[aliased_path] = tracer
 

--- a/src/pr_agent_context/prompt/render.py
+++ b/src/pr_agent_context/prompt/render.py
@@ -273,11 +273,18 @@ def _build_opening_instructions(
     ]
     if not disabled_checks:
         return refresh_note + DEFAULT_ALL_CLEAR_PROMPT.format(
-            pr_number=pull_request_number,
+            pr_reference=_format_pr_reference(
+                pull_request_number=pull_request_number,
+                repository_url=repository_url,
+            ),
         )
     return (
-        refresh_note + "No actionable items were found in the enabled checks for PR "
-        f"#{pull_request_number} at head commit {head_sha or 'unknown'}."
+        refresh_note + "No actionable items were found in the enabled checks for "
+        + _format_pr_reference(
+            pull_request_number=pull_request_number,
+            repository_url=repository_url,
+        )
+        + f" at head commit {head_sha or 'unknown'}."
         + "\n\n"
         + "Note: This assessment only covers the enabled checks for this run. "
         + "Skipped checks: "
@@ -308,13 +315,14 @@ def _build_actionable_opening_instructions(
             "a patch coverage gap" if patch_gap_count == 1 else "patch coverage gaps"
         )
     opening_subject = _join_human_list(signal_labels) or "actionable items"
+    pr_reference = _format_pr_reference(
+        pull_request_number=pull_request_number,
+        repository_url=repository_url,
+    )
 
-    repository_suffix = ""
+    opening_sentence = f"This run includes {opening_subject} on {pr_reference}"
     if repository_url and repository_url.strip():
-        repository_suffix = f" in repository {repository_url.strip()}"
-    opening_sentence = f"This run includes {opening_subject} on PR #{pull_request_number}"
-    if repository_suffix:
-        lines = [f"{opening_sentence}{repository_suffix}"]
+        lines = [opening_sentence]
     else:
         lines = [f"{opening_sentence}."]
     if review_item_count:
@@ -344,6 +352,12 @@ def _build_actionable_opening_instructions(
         ]
     )
     return "\n".join(lines)
+
+
+def _format_pr_reference(*, pull_request_number: int, repository_url: str | None) -> str:
+    if repository_url and repository_url.strip():
+        return f"PR #{pull_request_number} in repository {repository_url.strip()}"
+    return f"PR #{pull_request_number}"
 
 
 def _build_review_follow_up_instructions(

--- a/src/pr_agent_context/prompt/render.py
+++ b/src/pr_agent_context/prompt/render.py
@@ -279,7 +279,8 @@ def _build_opening_instructions(
             ),
         )
     return (
-        refresh_note + "No actionable items were found in the enabled checks for "
+        refresh_note
+        + "No actionable items were found in the enabled checks for "
         + _format_pr_reference(
             pull_request_number=pull_request_number,
             repository_url=repository_url,

--- a/src/pr_agent_context/prompt/render.py
+++ b/src/pr_agent_context/prompt/render.py
@@ -44,6 +44,7 @@ from pr_agent_context.prompt.truncate import truncate_lines, truncate_text
 def render_prompt(
     *,
     pull_request_number: int,
+    repository_url: str | None = None,
     head_sha: str | None = None,
     run_id: int = 0,
     run_attempt: int = 1,
@@ -117,6 +118,7 @@ def render_prompt(
             "prompt_preamble": prompt_preamble.strip(),
             "opening_instructions": _build_opening_instructions(
                 pull_request_number=pull_request_number,
+                repository_url=repository_url,
                 head_sha=head_sha,
                 has_actionable_items=has_actionable_items,
                 review_item_count=len(review_threads) if include_review_comments else 0,
@@ -234,6 +236,7 @@ def build_managed_comment_body(
 def _build_opening_instructions(
     *,
     pull_request_number: int,
+    repository_url: str | None,
     head_sha: str | None,
     has_actionable_items: bool,
     review_item_count: int,
@@ -253,6 +256,7 @@ def _build_opening_instructions(
     if has_actionable_items:
         return refresh_note + _build_actionable_opening_instructions(
             pull_request_number=pull_request_number,
+            repository_url=repository_url,
             review_item_count=review_item_count,
             failing_check_count=failing_check_count,
             patch_gap_count=patch_gap_count,
@@ -285,6 +289,7 @@ def _build_opening_instructions(
 def _build_actionable_opening_instructions(
     *,
     pull_request_number: int,
+    repository_url: str | None,
     review_item_count: int,
     failing_check_count: int,
     patch_gap_count: int,
@@ -304,7 +309,14 @@ def _build_actionable_opening_instructions(
         )
     opening_subject = _join_human_list(signal_labels) or "actionable items"
 
-    lines = [f"This run includes {opening_subject} on PR #{pull_request_number}."]
+    repository_suffix = ""
+    if repository_url and repository_url.strip():
+        repository_suffix = f" in repository {repository_url.strip()}"
+    opening_sentence = f"This run includes {opening_subject} on PR #{pull_request_number}"
+    if repository_suffix:
+        lines = [f"{opening_sentence}{repository_suffix}"]
+    else:
+        lines = [f"{opening_sentence}."]
     if review_item_count:
         lines.extend(
             [

--- a/src/pr_agent_context/services/run.py
+++ b/src/pr_agent_context/services/run.py
@@ -361,7 +361,9 @@ def run_service(config: RunConfig, *, client: GitHubApiClient | None = None) -> 
     )
     rendered = render_prompt(
         pull_request_number=pull_request.number,
-        repository_url=f"https://github.com/{pull_request.owner}/{pull_request.repo}",
+        repository_url=(
+            f"{config.github_server_url.rstrip('/')}/{pull_request.owner}/{pull_request.repo}"
+        ),
         head_sha=pull_request.head_sha,
         run_id=config.run_id,
         run_attempt=config.run_attempt,

--- a/src/pr_agent_context/services/run.py
+++ b/src/pr_agent_context/services/run.py
@@ -361,6 +361,7 @@ def run_service(config: RunConfig, *, client: GitHubApiClient | None = None) -> 
     )
     rendered = render_prompt(
         pull_request_number=pull_request.number,
+        repository_url=f"https://github.com/{pull_request.owner}/{pull_request.repo}",
         head_sha=pull_request.head_sha,
         run_id=config.run_id,
         run_attempt=config.run_attempt,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,6 +59,7 @@ def test_run_config_from_env(tmp_path):
     config = RunConfig.from_env(
         {
             "GITHUB_REPOSITORY": "shaypal5/example",
+            "GITHUB_SERVER_URL": "https://github.enterprise.example",
             "GITHUB_EVENT_PATH": str(event_path),
             "GITHUB_RUN_ID": "123",
             "GITHUB_RUN_ATTEMPT": "4",
@@ -105,6 +106,8 @@ def test_run_config_from_env(tmp_path):
     )
 
     assert config.tool_ref == "v4"
+    assert config.github_server_url == "https://github.enterprise.example"
+    assert config.repository_url == "https://github.enterprise.example/shaypal5/example"
     assert config.pull_request.owner == "shaypal5"
     assert config.pull_request.repo == "example"
     assert config.pull_request.number == 17
@@ -858,6 +861,7 @@ def test_run_config_auto_execution_mode_resolves_by_event_name(
 def test_run_config_repository_property_prefers_explicit_repository_fields(tmp_path):
     config = RunConfig(
         github_token="token",
+        github_server_url="https://github.enterprise.example/",
         repository_owner="shaypal5",
         repository_name="example",
         run_id=1,
@@ -866,6 +870,7 @@ def test_run_config_repository_property_prefers_explicit_repository_fields(tmp_p
     )
 
     assert config.repository == "shaypal5/example"
+    assert config.repository_url == "https://github.enterprise.example/shaypal5/example"
 
 
 def test_run_config_repository_property_falls_back_to_pull_request(tmp_path):

--- a/tests/test_patch_coverage.py
+++ b/tests/test_patch_coverage.py
@@ -73,6 +73,23 @@ def _build_coverage_data_with_recorded_filenames(
     coverage.save()
 
 
+def _build_branch_coverage_data_with_recorded_filenames(
+    data_file: Path,
+    scripts: list[tuple[str, Path, str]],
+) -> None:
+    coverage = Coverage(branch=True, config_file=False, data_file=str(data_file))
+    coverage.start()
+    for recorded_filename, script_path, invocation in scripts:
+        globals_dict = {"__name__": "__main__"}
+        exec(
+            compile(script_path.read_text(encoding="utf-8"), recorded_filename, "exec"),
+            globals_dict,
+        )
+        exec(invocation, globals_dict)
+    coverage.stop()
+    coverage.save()
+
+
 def _build_coverage_data_with_workspace_config(
     *,
     workspace: Path,
@@ -1298,6 +1315,39 @@ def test_build_combined_coverage_adds_workspace_alias_for_absolute_split_checkou
     combined = build_combined_coverage(workspace=repo, coverage_files=[coverage_file])
     measured_files = set(combined.get_data().measured_files())
 
+    assert str(source_path.resolve()) in measured_files
+    assert combined.analysis2(str(source_path))[3] == [4]
+
+
+def test_build_combined_coverage_adds_workspace_aliases_for_branch_data(tmp_path):
+    job_workspace = tmp_path / "job-workspace"
+    repo = job_workspace / "caller-repo"
+    repo.mkdir(parents=True)
+    source_path = repo / "src" / "pkg" / "module.py"
+    _write_file(
+        source_path,
+        "def parse(flag):\n    if flag:\n        return 1\n    return 2\n",
+    )
+
+    coverage_dir = job_workspace / "coverage-artifacts"
+    coverage_dir.mkdir(parents=True)
+    coverage_file = coverage_dir / ".coverage.py312"
+    _build_branch_coverage_data_with_recorded_filenames(
+        coverage_file,
+        [
+            (
+                "/home/runner/work/pr-agent-context/pr-agent-context/src/pkg/module.py",
+                source_path,
+                "parse(True)",
+            )
+        ],
+    )
+
+    combined = build_combined_coverage(workspace=repo, coverage_files=[coverage_file])
+    data = combined.get_data()
+    measured_files = set(data.measured_files())
+
+    assert data.has_arcs() is True
     assert str(source_path.resolve()) in measured_files
     assert combined.analysis2(str(source_path))[3] == [4]
 

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -611,6 +611,7 @@ def test_render_prompt_can_publish_all_clear_comment_in_refresh_mode_when_enable
 def test_render_prompt_all_clear_notes_when_some_signal_types_are_disabled():
     rendered = render_prompt(
         pull_request_number=17,
+        repository_url="https://github.com/shaypal5/example",
         head_sha="feedface",
         review_threads=[],
         failing_checks=[],
@@ -620,10 +621,29 @@ def test_render_prompt_all_clear_notes_when_some_signal_types_are_disabled():
         include_patch_coverage=False,
     )
 
-    assert "No actionable items were found in the enabled checks" in rendered.prompt_markdown
+    assert (
+        "No actionable items were found in the enabled checks for PR #17 in repository "
+        "https://github.com/shaypal5/example at head commit feedface."
+    ) in rendered.prompt_markdown
     assert "only covers the enabled checks for this run" in rendered.prompt_markdown
     assert "Skipped checks: review comments," in rendered.prompt_markdown
     assert "patch coverage." in rendered.prompt_markdown
+
+
+def test_render_prompt_all_clear_includes_repository_url_when_available():
+    rendered = render_prompt(
+        pull_request_number=17,
+        repository_url="https://github.com/shaypal5/example",
+        head_sha="feedface",
+        review_threads=[],
+        failing_checks=[],
+        patch_coverage=None,
+    )
+
+    assert (
+        "No unresolved review comments, failing checks, or actionable patch coverage gaps "
+        "were found on PR #17 in repository https://github.com/shaypal5/example."
+    ) in rendered.prompt_markdown
 
 
 def test_render_prompt_hides_approval_gated_note_section_by_default():

--- a/tests/test_render.py
+++ b/tests/test_render.py
@@ -362,6 +362,22 @@ def test_render_prompt_builds_signal_specific_openings(
         assert "After I reply with my decision per item" not in rendered.prompt_markdown
 
 
+def test_render_prompt_includes_repository_url_in_actionable_opening_when_available():
+    rendered = render_prompt(
+        pull_request_number=25,
+        repository_url="https://github.com/leadforge-dev/leadforge",
+        head_sha="feedface",
+        review_threads=[_sample_review_thread()],
+        failing_checks=[_sample_failing_check()],
+        patch_coverage=None,
+    )
+
+    assert (
+        "This run includes an unresolved review comment and a failing check on PR #25 in "
+        "repository https://github.com/leadforge-dev/leadforge"
+    ) in rendered.prompt_markdown
+
+
 def test_render_prompt_all_three_signals_use_pluralized_opening():
     rendered = render_prompt(
         pull_request_number=17,

--- a/tests/test_run_service.py
+++ b/tests/test_run_service.py
@@ -839,6 +839,10 @@ def test_run_service_writes_debug_artifacts(tmp_path, issue_comments_payload):
     assert comment_sync["sync_debug"]["hidden_comment_ids"] == []
     assert comment_sync["sync_debug"]["hide_errors"] == []
     assert prompt_text.startswith("Repository: foldermix")
+    assert (
+        "This run includes unresolved review comments on PR #17 in repository "
+        "https://github.com/shaypal5/example"
+    ) in prompt_text
     assert comment_body.startswith(
         "<!-- pr-agent-context:managed-comment; schema=v5; publish_mode=append;"
     )

--- a/tests/test_run_service.py
+++ b/tests/test_run_service.py
@@ -860,6 +860,26 @@ def test_run_service_writes_debug_artifacts(tmp_path, issue_comments_payload):
     assert "Status: outdated" in comment_body
 
 
+def test_run_service_uses_configured_github_server_url(tmp_path, issue_comments_payload):
+    client = FakeGitHubClient(
+        review_threads_payload=load_json_fixture("github/review_threads.json"),
+        workflow_jobs_payload={"jobs": []},
+        issue_comments_payload=[issue_comments_payload[0]],
+    )
+    config = _build_config(
+        tmp_path,
+        github_server_url="https://github.enterprise.example/",
+    )
+
+    assert run_service(config, client=client) == 0
+
+    prompt_text = (config.debug_artifacts_dir / "prompt.md").read_text(encoding="utf-8")
+    assert (
+        "This run includes unresolved review comments on PR #17 in repository "
+        "https://github.enterprise.example/shaypal5/example"
+    ) in prompt_text
+
+
 def test_run_service_can_skip_outdated_review_threads(tmp_path, issue_comments_payload):
     client = FakeGitHubClient(
         review_threads_payload=load_json_fixture("github/review_threads.json"),


### PR DESCRIPTION
## Problem

The default pr-agent-context opening sentence identifies the PR number but not the repository URL. When the rendered context is copied or consumed outside the GitHub PR page, the agent has less explicit repository context than it needs.

While validating this PR through the repo's own refresh workflow, pr-agent-context also hit a fatal patch-coverage reconstruction path for branch-coverage artifacts:

```text
coverage.exceptions.DataError: Can't add line measurements to existing branch data
```

That happened because CI produces raw coverage artifacts with `--cov-branch`, but workspace-relative filename aliasing tried to add line measurements before adding arc measurements.

## Changes

- Adds an optional `repository_url` value to prompt rendering and uses it in actionable, all-clear, and disabled-check opening instructions.
- Captures `GITHUB_SERVER_URL` in run config and uses it to build repository URLs, so GitHub Enterprise installations do not get hardcoded `github.com` links.
- Documents the visible default prompt wording in the README.
- Updates coverage filename aliasing so branch/arc coverage data receives arc aliases and line-only coverage data receives line aliases.
- Adds render, service, config, and branch-coverage alias regression coverage.
- Cleans up the touched `config.py` Ruff `UP038` lint while adding server URL config support.

## Review handling

- Broadened repository URL wording beyond actionable openings in response to Copilot's README comment.
- Replaced the hardcoded `github.com` repository URL with `GITHUB_SERVER_URL` plumbing for GitHub Enterprise compatibility.
- Intentionally left the actionable opening without a trailing period after a raw repository URL to preserve the requested output shape.

## Validation

- `pytest tests/test_render.py tests/test_run_service.py`
- `pytest tests/test_patch_coverage.py`
- `pytest tests/test_render.py tests/test_run_service.py tests/test_config.py`
- `pytest`
- `ruff check src/pr_agent_context/prompt/render.py src/pr_agent_context/services/run.py tests/test_render.py tests/test_run_service.py`
- `ruff check src/pr_agent_context/coverage/combine.py tests/test_patch_coverage.py`
- `ruff check src/pr_agent_context/config.py src/pr_agent_context/constants.py src/pr_agent_context/prompt/render.py src/pr_agent_context/services/run.py tests/test_config.py tests/test_render.py tests/test_run_service.py`
- Locally reproduced the previous refresh failure with raw artifacts from CI run `25147252116`, then verified `build_combined_coverage()` combines those three branch-coverage artifacts successfully after this fix.
