### PR TITLE
Bump version to 4.0.21

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "pr-agent-context"
-version = "4.0.20"
+version = "4.0.21"
 description = "Reusable GitHub Actions tool for assembling PR handoff context for coding agents."
 readme = "README.md"
 license = "MIT"

--- a/tests/fixtures/prompts/expected_comment.md
+++ b/tests/fixtures/prompts/expected_comment.md
@@ -75,7 +75,7 @@ Excerpt:
 Run metadata:
 ```
 Tool ref: v4
-Tool version: 4.0.20
+Tool version: 4.0.21
 Trigger: pull request updated
 Workflow run: 0 attempt 1
 Comment timestamp: unknown

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -15,7 +15,7 @@ def test_version_falls_back_to_pyproject_when_package_metadata_is_unavailable(
 
     reloaded = importlib.reload(package)
 
-    assert reloaded.__version__ == "4.0.20"
+    assert reloaded.__version__ == "4.0.21"
 
 
 def test_read_pyproject_version_reads_from_source_checkout(tmp_path, monkeypatch):
@@ -74,7 +74,7 @@ def test_github_api_client_defaults_user_agent_from_package_version():
 
     client = GitHubApiClient(token="token")
 
-    assert client._user_agent == "pr-agent-context/4.0.20"
+    assert client._user_agent == "pr-agent-context/4.0.21"
 
 
 def test_github_api_client_respects_explicit_user_agent_override():


### PR DESCRIPTION
## Problem

The merged prompt repository-context and branch-coverage alias fixes need a patch release so downstream users can consume them through the stable `v4` line.

## Changes

- Bumps package version from `4.0.20` to `4.0.21` in `pyproject.toml`.
- Updates version assertions in `tests/test_version.py`.
- Updates the managed-comment fixture's rendered tool version.

## Validation

- `pytest tests/test_version.py tests/test_render.py -q`
- `ruff check tests/test_version.py`

## Post-merge release step

After this PR merges, refresh `main`, tag the merged tip as `v4.0.21`, and push the tag. The release-tags workflow will move the `v4` major tag.
