### PR TITLE
Fix scheduled refresh workflow runs API call

### DIFF
--- a/.github/workflows/pr-agent-context-refresh.yml
+++ b/.github/workflows/pr-agent-context-refresh.yml
@@ -113,7 +113,7 @@ jobs:
             const recentDispatchWindowMs = 60 * 60 * 1000;
 
             const recentDispatchCutoff = Date.now() - recentDispatchWindowMs;
-            const { data: workflowRunsResponse } = await github.rest.actions.listWorkflowRunsForWorkflow({
+            const { data: workflowRunsResponse } = await github.rest.actions.listWorkflowRuns({
               owner,
               repo,
               workflow_id: 'pr-agent-context-refresh.yml',

--- a/README.md
+++ b/README.md
@@ -401,7 +401,7 @@ jobs:
             const recentDispatchWindowMs = 60 * 60 * 1000;
 
             const recentDispatchCutoff = Date.now() - recentDispatchWindowMs;
-            const { data: workflowRunsResponse } = await github.rest.actions.listWorkflowRunsForWorkflow({
+            const { data: workflowRunsResponse } = await github.rest.actions.listWorkflowRuns({
               owner,
               repo,
               workflow_id: 'pr-agent-context-refresh.yml',

--- a/examples/pr-agent-context-refresh.yml
+++ b/examples/pr-agent-context-refresh.yml
@@ -113,7 +113,7 @@ jobs:
             const recentDispatchWindowMs = 60 * 60 * 1000;
 
             const recentDispatchCutoff = Date.now() - recentDispatchWindowMs;
-            const { data: workflowRunsResponse } = await github.rest.actions.listWorkflowRunsForWorkflow({
+            const { data: workflowRunsResponse } = await github.rest.actions.listWorkflowRuns({
               owner,
               repo,
               workflow_id: 'pr-agent-context-refresh.yml',

--- a/tests/test_workflow_contracts.py
+++ b/tests/test_workflow_contracts.py
@@ -5,6 +5,11 @@ from pathlib import Path
 import yaml
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
+REFRESH_WORKFLOW_SNIPPET_PATHS = (
+    ".github/workflows/pr-agent-context-refresh.yml",
+    "examples/pr-agent-context-refresh.yml",
+    "README.md",
+)
 
 
 def _load_workflow(relative_path: str) -> dict[str, object]:
@@ -28,3 +33,14 @@ def test_self_refresh_uses_local_reusable_workflow_contract():
         refresh_job["with"]["tool_ref"] == "${{ github.event.pull_request.head.sha || github.sha }}"
     )
     assert set(refresh_job["with"]).issubset(set(reusable_inputs))
+
+
+def test_refresh_snippets_use_supported_workflow_runs_method():
+    unsupported_method = "github.rest.actions.listWorkflowRunsForWorkflow"
+    supported_method = "github.rest.actions.listWorkflowRuns({"
+
+    for relative_path in REFRESH_WORKFLOW_SNIPPET_PATHS:
+        snippet = (REPO_ROOT / relative_path).read_text(encoding="utf-8")
+
+        assert unsupported_method not in snippet
+        assert supported_method in snippet


### PR DESCRIPTION
## Problem

The scheduled refresh fanout snippet calls `github.rest.actions.listWorkflowRunsForWorkflow`, but that method is not available in the Octokit client exposed by `actions/github-script@v7`. Downstream repositories that copied the snippet fail before dispatching refreshes with:

```text
TypeError: github.rest.actions.listWorkflowRunsForWorkflow is not a function
```

## Changes

- Replace the invalid `listWorkflowRunsForWorkflow` method with `listWorkflowRuns` in this repo's self-refresh workflow.
- Apply the same fix to the documented README snippet.
- Apply the same fix to the example refresh workflow that client repos copy from.

## Impact

Scheduled refresh fanout runs can query recent `workflow_dispatch` runs again, and future client integrations should copy a working Octokit call.

## Validation

- `rg -n "listWorkflowRunsForWorkflow" .` returns no matches.
- `pre-commit run --files .github/workflows/pr-agent-context-refresh.yml README.md examples/pr-agent-context-refresh.yml` passed.