### PR TITLE
Improve README presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,35 @@
 `pr-agent-context` is a reusable GitHub Actions tool that assembles managed
 PR handoff comments for coding agents.
 
+Created by [Shay Palachy Affek](http://www.shaypalachy.com/).
+
+## Quick Mental Model
+
+`pr-agent-context` turns live PR state into a durable handoff comment:
+
+```text
+PR review threads + failing checks + patch coverage + caller template
+                         |
+                         v
+          managed GitHub PR comment for coding agents
+                         |
+                         v
+        refresh runs keep later review/check signals visible
+```
+
+See an abbreviated generated artifact in
+[`docs/managed-comment-preview.md`](docs/managed-comment-preview.md).
+
+## README Map
+
+- [Downstream Usage](#downstream-usage): minimal reusable-workflow setup and versioning.
+- [Prompt Templating](#prompt-templating): customize the rendered handoff prompt.
+- [Refresh Mode](#refresh-mode): keep review/check updates visible after initial CI.
+- [Coverage Artifact Contract](#coverage-artifact-contract): feed patch coverage from artifacts.
+- [Debug Artifacts](#debug-artifacts): inspect deterministic JSON and Markdown outputs.
+- [PR-Wide Failing Checks](#pr-wide-failing-checks): understand check aggregation behavior.
+- [Patch Coverage Rules](#patch-coverage-rules): know what counts in patch coverage.
+
 Current behavior includes:
 
 - unresolved PR review threads
@@ -813,3 +842,7 @@ source = [
 If a repo uses unusual layout or aggressive path rewriting, `pr-agent-context` will still merge
 the available `.coverage*` files locally, but checked-in `coverage.py` config remains the safest
 option because it removes any ambiguity from source-scope inference.
+
+## Credits
+
+Created by [Shay Palachy Affek ](http://www.shaypalachy.com/) [[GitHub](https://github.com/shaypal5)]

--- a/docs/managed-comment-preview.md
+++ b/docs/managed-comment-preview.md
@@ -1,0 +1,51 @@
+# Managed Comment Preview
+
+This abbreviated example shows the shape of the PR comment that
+`pr-agent-context` publishes for coding agents. Real comments include the same
+managed marker and run metadata, with sections populated from the current PR.
+
+````markdown
+<!-- pr-agent-context:managed-comment; schema=v5; publish_mode=append; execution_mode=ci; pr=42; head_sha=abc123; trigger_event=pull_request; generated_at=2026-05-30T12:34:56Z; tool_ref=v4; run_id=123456789; run_attempt=1 -->
+pr-agent-context report:
+```markdown
+# PR 42
+
+This run includes unresolved review comments, failing checks, and patch
+coverage findings for the current PR head.
+
+## Unresolved Review Comments
+
+### COPILOT-1
+Location: src/example.py:37
+URL: https://github.com/example/repo/pull/42#discussion_r123
+
+Comment:
+    This branch accepts an empty payload and later crashes. Add validation
+    before constructing the request object.
+
+## Failing Checks
+
+### test (ubuntu-latest, py3.12)
+Conclusion: failure
+Details: https://github.com/example/repo/actions/runs/123456789/job/987654321
+
+Failed step output:
+    AssertionError: expected retry_count == 3
+
+## Patch Coverage
+
+Target: 100%
+Actual: 91.67%
+
+Uncovered changed executable Python lines:
+- src/example.py: 37
+```
+Run metadata:
+```
+Tool ref: v4
+Tool version: 4.0.21
+Workflow run: 123456789 attempt 1
+Comment timestamp: 2026-05-30T12:34:56Z
+PR head commit: abc123
+```
+````


### PR DESCRIPTION
## Summary

Improve the GitHub landing-page presentation for pr-agent-context so a first-time reader can understand the input-to-output workflow quickly before entering the long reference sections.

## Changes

- Add the required creator attribution near the top and the current Credits block at the bottom.
- Add a "Quick Mental Model" section showing PR inputs flowing into a managed GitHub PR comment and refresh lifecycle.
- Add a README map for the major long-form reference sections.
- Add `docs/managed-comment-preview.md` with an abbreviated example of the generated managed PR handoff comment.

## GitHub metadata

Updated directly on the repository card with `gh repo edit`:

- Topics: `github-actions`, `pull-requests`, `coding-agents`, `llm`, `automation`, `python`

The existing repository description was already accurate, so it was left unchanged.

## Validation

- `git diff --check -- README.md docs/managed-comment-preview.md`
- README and preview smoke check: exactly two creator-credit occurrences, Credits at the bottom, quick mental model present, README map present, preview linked, managed-comment marker present
- `python -m pytest` passed: 412 tests
